### PR TITLE
Make the website adjustable based on the screen sizes

### DIFF
--- a/shared/components/Home.css
+++ b/shared/components/Home.css
@@ -8,3 +8,9 @@
 * {
     font-family: "SF Pro", sans-serif;
 }
+
+@media all and (max-width:850px){
+    .home{
+        display: block;
+    }
+}


### PR DESCRIPTION
When the device's width is less than 850px, the website will be displayed by block instead of grid. 
Here is a screenshot of what it would look like on an iPhone 12 Pro
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/96160110/231932903-c889cfc2-4a83-4c6f-8345-8911309a96a8.png">

I decided to make 850px the max width because I thought the website looked too crowded when the screen size was less than that.

This is what it looks like when the max width is 850px
<img width="638" alt="image" src="https://user-images.githubusercontent.com/96160110/231934104-507026b6-59df-4d15-af6c-676119483b81.png">




