### PR TITLE
Make the website swipeable in phone screen using 'react-swipeable-views'

### DIFF
--- a/shared/components/Home.tsx
+++ b/shared/components/Home.tsx
@@ -1,12 +1,15 @@
 import Location from "./Location";
 import React from "react";
-import "./Home.css"
+import "./Home.css";
+import SwipeableViews from "react-swipeable-views";
+
+
 function Home(){
     return (
-        <div className="home">
+        <SwipeableViews enableMouseEvents className="home">
             <Location location = "brandywine"/>
             <Location location = "anteatery"/>
-        </div>
+        </SwipeableViews>
     )
 }
 export default Home


### PR DESCRIPTION
I install the 'react-swipeable-views' npm package to solve this. Now, when the screen size is less than 850px, the content will be displayed by block, and the user can swipe the website to change from Brandywine to Anteatery and vice versa.

Here is the official website of the npm package I use:[]( https://react-swipeable-views.com/getting-started/installation/)