### PR TITLE
Fix Netlify Previews

### DIFF
--- a/zotmeal-vite/netlify.toml
+++ b/zotmeal-vite/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../shared/"


### PR DESCRIPTION
Right now the Netlify preview deploys aren't doing anything because it doesn't see any changes so it cancels the build. I think it should be a simple fix with a custom `netlify.toml`file to override the default settings, so if it works this PR should see a working deployment.