### PR TITLE
Migrate backend (Rewrite endpoint for getting the menu,schedule, and other datas )

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/
 node_modules
 .DS_Store
+# Local Netlify folder
+.netlify

--- a/backend/util.ts
+++ b/backend/util.ts
@@ -1,0 +1,48 @@
+//Relevant Nutrition Properties
+export const NUTRITION_PROPERTIES = [
+    'IsVegan',
+    'IsVegetarian',
+    'ServingSize',
+    'ServingUnit',
+    'Calories',
+    'CaloriesFromFat',
+    'TotalFat',
+    'TransFat',
+    'Cholesterol',
+    'Sodium',
+    'TotalCarbohydrates',
+    'DietaryFiber',
+    'Sugars',
+    'Protein',
+    'VitaminA',
+    'VitaminC',
+    'Calcium',
+    'Iron',
+    'SaturatedFat'
+]
+
+export const DEFAULT_PRICES = {
+    'breakfast': 9.75,
+    'lunch': 13.75,
+    'brunch': 13.75,
+    'dinner': 14.95
+}
+
+export const MEAL_TO_PERIOD = {
+    breakfast: 49,
+    lunch: 106,
+    dinner: 107,
+    brunch: 2651,
+};
+  
+
+export const LOCATION_ID= {
+     "brandywine":"3314",
+     "anteatery":"3056",
+}
+
+export function getMealPeriods(time) { 
+    return new Date(time).toLocaleTimeString('en-US', { timeZone:"America/Los_Angeles", hour: '2-digit', minute: '2-digit' })
+}
+
+


### PR DESCRIPTION
The serverless functions now be able to get the schedule(without web scrape), menu(formatted by stations where each station contains different categories and items inside the category), items data(name, description, nutrition, icons), and pricing

Here is the output when running locally 
http://localhost:8888/api/menucall?location=brandywine&date=11/18/2023&meal=dinner

<img width="987" alt="image" src="https://github.com/icssc/ZotMeal/assets/96160110/fce3af13-a7dd-4d32-9883-ed3a194642a0">
