### PR TITLE
make schedule and price into separate functions

### DIFF
--- a/backend/functions/menucall.ts
+++ b/backend/functions/menucall.ts
@@ -1,5 +1,5 @@
 import type { Handler, HandlerEvent, HandlerContext } from "@netlify/functions";
-import { DEFAULT_PRICES, NUTRITION_PROPERTIES, MEAL_TO_PERIOD, LOCATION_ID } from "../util";
+import { NUTRITION_PROPERTIES, MEAL_TO_PERIOD, LOCATION_ID } from "../util";
 
 const axios = require("axios");
 const handler: Handler = async (
@@ -92,7 +92,6 @@ const handler: Handler = async (
 
     // build the data we want to return to the client
     const data = {
-      "price": DEFAULT_PRICES,
       "all": all
     };
 

--- a/backend/functions/menucall.ts
+++ b/backend/functions/menucall.ts
@@ -1,5 +1,5 @@
 import type { Handler, HandlerEvent, HandlerContext } from "@netlify/functions";
-import { DEFAULT_PRICES, NUTRITION_PROPERTIES, MEAL_TO_PERIOD, LOCATION_ID, getMealPeriods } from "../util";
+import { DEFAULT_PRICES, NUTRITION_PROPERTIES, MEAL_TO_PERIOD, LOCATION_ID } from "../util";
 
 const axios = require("axios");
 const handler: Handler = async (

--- a/backend/functions/menucall.ts
+++ b/backend/functions/menucall.ts
@@ -21,14 +21,6 @@ const handler: Handler = async (
   try {
     const response = await axios.get(apicallurl);
 
-    // Turn schedule data into the format of {period: {start: time, end: time}
-    const schedule = {}
-    for (const period of response.data.Menu.MenuPeriods) {
-      schedule[period.Name] = {
-        "start": getMealPeriods(period.UtcMealPeriodStartTime),
-        "end": getMealPeriods(period.UtcMealPeriodEndTime)
-      };
-    }
     
     
     // stations = {stationId: stationName}
@@ -100,7 +92,6 @@ const handler: Handler = async (
 
     // build the data we want to return to the client
     const data = {
-      "schedule": schedule,
       "price": DEFAULT_PRICES,
       "all": all
     };

--- a/backend/functions/price.ts
+++ b/backend/functions/price.ts
@@ -19,7 +19,7 @@ const handler: Handler = async (
     return {
       statusCode: 500,
       body: JSON.stringify({
-        message: "There is no menu today",
+        message: "There is no pricing today",
       }),
     };
   }

--- a/backend/functions/price.ts
+++ b/backend/functions/price.ts
@@ -1,0 +1,28 @@
+import type { Handler, HandlerEvent, HandlerContext } from "@netlify/functions";
+import { DEFAULT_PRICES } from "../util";
+
+const handler: Handler = async (
+  event: HandlerEvent,
+  context: HandlerContext
+) => {
+  try {
+    // build the data we want to return to the client
+    const data = {
+      prices: DEFAULT_PRICES,
+    };
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify(data, null, 4),
+    };
+  } catch (error) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        message: "There is no menu today",
+      }),
+    };
+  }
+};
+
+export { handler };

--- a/backend/functions/schedule.ts
+++ b/backend/functions/schedule.ts
@@ -1,8 +1,5 @@
 import type { Handler, HandlerEvent, HandlerContext } from "@netlify/functions";
 import {
-  DEFAULT_PRICES,
-  NUTRITION_PROPERTIES,
-  MEAL_TO_PERIOD,
   LOCATION_ID,
   getMealPeriods,
 } from "../util";

--- a/backend/functions/schedule.ts
+++ b/backend/functions/schedule.ts
@@ -1,0 +1,55 @@
+import type { Handler, HandlerEvent, HandlerContext } from "@netlify/functions";
+import {
+  DEFAULT_PRICES,
+  NUTRITION_PROPERTIES,
+  MEAL_TO_PERIOD,
+  LOCATION_ID,
+  getMealPeriods,
+} from "../util";
+
+const axios = require("axios");
+const handler: Handler = async (
+  event: HandlerEvent,
+  context: HandlerContext
+) => {
+  const location = event.queryStringParameters?.location;
+  const date = event.queryStringParameters?.date;
+
+  const location_id = LOCATION_ID[location];
+
+  //  anteatery 01/14/2022
+  //  https://uci.campusdish.com/api/menu/GetMenus?locationId=3056&date=01/14/2022
+  let apicallurl = `https://uci.campusdish.com/api/menu/GetMenus?locationId=${location_id}&date=${date}`;
+
+  try {
+    const response = await axios.get(apicallurl);
+
+    // Turn schedule data into the format of {period: {start: time, end: time}
+    const schedule = {};
+    for (const period of response.data.Menu.MenuPeriods) {
+      schedule[period.Name] = {
+        start: getMealPeriods(period.UtcMealPeriodStartTime),
+        end: getMealPeriods(period.UtcMealPeriodEndTime),
+      };
+    }
+
+    // build the data we want to return to the client
+    const data = {
+      schedule: schedule,
+    };
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify(data, null, 4),
+    };
+  } catch (error) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        message: "There is no schedule today",
+      }),
+    };
+  }
+};
+
+export { handler };


### PR DESCRIPTION
Remove schedule data from the menucall function. 
Get anteatery lunch menu on 11/27/2023 with http://localhost:8888/api/menucall?location=anteatery&date=11/27/2023&meal=lunch when running locally
<img width="867" alt="image" src="https://github.com/icssc/ZotMeal/assets/96160110/e6edcfa9-ed4d-4d51-94ba-d0a80874ae24">

Schedule data is now in a separate function
Get anteatery schedule on 11/27/2023 with http://localhost:8888/api/schedule?location=anteatery&date=11/27/2023 when running locally
<img width="480" alt="image" src="https://github.com/icssc/ZotMeal/assets/96160110/175b0225-8256-460f-b9c9-e83271f81534">

Price is now a separate function
Get pricing with http://localhost:8888/api/price
<img width="328" alt="image" src="https://github.com/icssc/ZotMeal/assets/96160110/3b8221fa-69d0-4548-a7e2-6844b025834b">


close #30
close #50