### PR TITLE
feat(cron): Initialize getWeekly and updateDaily jobs, validate cron …

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -19,6 +19,7 @@
     "@types/aws-lambda": "^8.10.133",
     "@types/node": "^20.11.17",
     "axios": "^1.6.7",
+    "date-fns": "^3.3.1",
     "serverless-esbuild": "^1.51.0",
     "serverless-offline": "^13.3.3"
   }

--- a/apps/server/src/functions/cron/getWeeklyHandler.ts
+++ b/apps/server/src/functions/cron/getWeeklyHandler.ts
@@ -1,0 +1,12 @@
+import { format } from "date-fns";
+
+export const main = async (event, context) => {
+  try {
+    const now = new Date();
+    const formattedTime = format(now, "yyyy-MM-dd'T'HH:mm:ss.SSSxxx");
+    console.log(`Weekly task executed at: ${formattedTime}`);
+    //TODO: get data from campusdish and put in db
+  } catch (error) {
+    console.error("Failed to execute weekly task", error);
+  }
+};

--- a/apps/server/src/functions/cron/testLog.ts
+++ b/apps/server/src/functions/cron/testLog.ts
@@ -1,0 +1,11 @@
+import { format } from "date-fns";
+
+export const main = async (event, context) => {
+  try {
+    const now = new Date();
+    const formattedTime = format(now, "yyyy-MM-dd'T'HH:mm:ss.SSSxxx");
+    console.log(`Time: ${formattedTime}`);
+  } catch (error) {
+    console.error("Failed to execute weekly task", error);
+  }
+};

--- a/apps/server/src/functions/cron/updateDailyHandler.ts
+++ b/apps/server/src/functions/cron/updateDailyHandler.ts
@@ -1,0 +1,12 @@
+import { format } from "date-fns";
+
+export const main = async (event, context) => {
+  try {
+    const now = new Date();
+    const formattedTime = format(now, "yyyy-MM-dd'T'HH:mm:ss.SSSxxx");
+    console.log(`Weekly task executed at: ${formattedTime}`);
+    //TODO: get data from campusdish and update in db
+  } catch (error) {
+    console.error("Failed to execute weekly task", error);
+  }
+};

--- a/apps/server/src/functions/index.ts
+++ b/apps/server/src/functions/index.ts
@@ -1,9 +1,9 @@
 import type { AWS } from "@serverless/typescript";
 
 export const functions: AWS["functions"] = {
-  hello: {
+  api: {
     handler: "src/functions/trpc/handler.main",
-    description: "Lambda function to say hello",
+    description: "Entry point for all tRPC routes defined within the appRouter",
     memorySize: 256,
     events: [
       {
@@ -11,6 +11,39 @@ export const functions: AWS["functions"] = {
           method: "any", // Match any HTTP method
           path: "/{proxy+}", // Use a catch-all wildcard here
           cors: true,
+        },
+      },
+    ],
+  },
+  // testLog: {
+  //   handler: "src/functions/cron/testLog.main",
+  //   events: [
+  //     {
+  //       schedule: {
+  //         rate: ["cron(* * * * ? *)"], //Runs every min. https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html
+  //         enabled: true,
+  //       },
+  //     },
+  //   ],
+  // },
+  getWeekly: {
+    handler: "src/functions/cron/getWeeklyHandler.main",
+    events: [
+      {
+        schedule: {
+          rate: ["cron(0 0 ? * 1 *)"], //Runs at 00:00 on Sunday. https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html
+          enabled: true,
+        },
+      },
+    ],
+  },
+  updateDaily: {
+    handler: "src/functions/cron/updateDailyHandler.main",
+    events: [
+      {
+        schedule: {
+          rate: ["cron(0 0 * * ? *)"], //Run daily at 00:00. https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cron-expressions.html
+          enabled: true,
         },
       },
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       axios:
         specifier: ^1.6.7
         version: 1.6.7
+      date-fns:
+        specifier: ^3.3.1
+        version: 3.3.1
       serverless-esbuild:
         specifier: ^1.51.0
         version: 1.51.0(esbuild@0.19.12)


### PR DESCRIPTION
## Describe your changes

- added cron folder in ```apps/server/src/functions``` to store the cronjob handlers
- set up getWeekly and updateDaily cron jobs to run weekly and daily respectively
- added a testLog cron job just for testing (already terminated to avoid cost). The testLog cron job is just a dummy cron job that log time each minute
- changed the name & description of the hello handler from api because it is the entry point for all tRPC routes defined within the appRouter.

Screenshot of CloudWatch log group below:
<img width="566" alt="image" src="https://github.com/icssc/ZotMeal/assets/96160110/644ae495-8909-4ef5-884e-d34bf0d6041d">


## Change Checklist

- [x] added cron folder in ```apps/server/src/functions``` to store the cronjob handlers
- [x] set up getWeekly and updateDaily cron jobs to run weekly and daily respectively
- [x] added a testLog cron job just for testing (already terminated to avoid cost). The testLog cron job is just a dummy cron job that log time each minute
- [x] changed the name & description of the handler from hello to api.

## Questions
- Is the folder structure correct? 
- Do we want tRPC for cron jobs?  Since the cron job is mainly to update the database without interacting with other tRPC procedures, I'm inclined to not use tRPC but would like to hear more opinions.
