### PR TITLE
feat: create events scraper and functionality to insert events into db

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -16,6 +16,7 @@
     "@zotmeal/tsconfig": "workspace:^",
     "@zotmeal/utils": "workspace:^",
     "@zotmeal/validators": "workspace:^",
+    "cheerio": "1.0.0-rc.12",
     "date-fns": "^3.3.1",
     "superjson": "2.2.1",
     "vitest": "^1.2.2",

--- a/packages/api/src/services/event.test.ts
+++ b/packages/api/src/services/event.test.ts
@@ -5,10 +5,8 @@ import { insertEvents, scrapeEvents } from "./event";
 describe("insert menu into db", () => {
   const db = new PrismaClient();
 
-  it("scrapes events data and returns it in the form of EventSchema", async () => {
-    let errorOccurred = false;
-
-    try {
+  it("scrapes events data and returns it in the form of EventSchema", () => {
+    expect(async () => {
       const events = await scrapeEvents();
 
       if (!events) {
@@ -16,44 +14,35 @@ describe("insert menu into db", () => {
       }
 
       console.log("events:", events);
-    } catch (e) {
-      if (e instanceof Error) {
-        console.error(e);
-        errorOccurred = true;
-      }
-    }
-
-    expect(errorOccurred).toBe(false);
+    }).not.toThrow();
   });
 
-  it("scrapes events data and inserts it into the db", async () => {
-    let errorOccurred = false;
+  it("scrapes events data and inserts it into the db", () => {
 
-    try {
-      const events = await scrapeEvents();
-      if (!events) {
-        throw new Error("events is null");
-      }
-
-      await db.$transaction(async (trx) => {
-        const insertedEvents = await insertEvents(trx, events);
-        if (!insertedEvents) {
-          throw new Error("insertedEvents is null");
+    expect(async () => {
+      try {
+        const events = await scrapeEvents();
+        if (!events) {
+          throw new Error("events is null");
         }
 
-        console.log("insertedEvents:", insertedEvents);
+        await db.$transaction(async (trx) => {
+          const insertedEvents = await insertEvents(trx, events);
+          if (!insertedEvents) {
+            throw new Error("insertedEvents is null");
+          }
 
-        // Rollback the transaction to undo the insert
-        throw new Error("rollback");
-      });
-    } catch (e) {
-      if (e instanceof Error && e.message !== 'rollback') {
-        console.error(e);
-        errorOccurred = true;
+          console.log("insertedEvents:", insertedEvents);
+
+          // Rollback the transaction to undo the insert
+          throw new Error("rollback");
+        });
+      } catch (e) {
+        if (e instanceof Error && e.message !== 'rollback') {
+          console.error(e);
+        }
       }
-    }
-
-    expect(errorOccurred).toBe(false);
+    }).not.toThrow();
   });
 
   // it("", () => {

--- a/packages/api/src/services/event.test.ts
+++ b/packages/api/src/services/event.test.ts
@@ -1,0 +1,66 @@
+import { PrismaClient } from "@zotmeal/db";
+import { afterAll, describe, expect, it } from "vitest";
+import { insertEvents, scrapeEvents } from "./event";
+
+describe("insert menu into db", () => {
+  const db = new PrismaClient();
+
+  it("scrapes events data and returns it in the form of EventSchema", async () => {
+    let errorOccurred = false;
+
+    try {
+      const events = await scrapeEvents();
+
+      if (!events) {
+        throw new Error("events is null");
+      }
+
+      console.log("events:", events);
+    } catch (e) {
+      if (e instanceof Error) {
+        console.error(e);
+        errorOccurred = true;
+      }
+    }
+
+    expect(errorOccurred).toBe(false);
+  });
+
+  it("scrapes events data and inserts it into the db", async () => {
+    let errorOccurred = false;
+
+    try {
+      const events = await scrapeEvents();
+      if (!events) {
+        throw new Error("events is null");
+      }
+
+      await db.$transaction(async (trx) => {
+        const insertedEvents = await insertEvents(trx, events);
+        if (!insertedEvents) {
+          throw new Error("insertedEvents is null");
+        }
+
+        console.log("insertedEvents:", insertedEvents);
+
+        // Rollback the transaction to undo the insert
+        throw new Error("rollback");
+      });
+    } catch (e) {
+      if (e instanceof Error && e.message !== 'rollback') {
+        console.error(e);
+        errorOccurred = true;
+      }
+    }
+
+    expect(errorOccurred).toBe(false);
+  });
+
+  // it("", () => {
+  //   // add an integration test, ideally using testcontainers
+  // });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+});

--- a/packages/api/src/services/event.ts
+++ b/packages/api/src/services/event.ts
@@ -1,0 +1,117 @@
+import type { Prisma, PrismaClient } from "@zotmeal/db";
+import { Event, EventSchema } from "@zotmeal/validators";
+import axios from "axios";
+import * as cheerio from "cheerio";
+
+async function getHTML(url: string) {
+  try {
+    const res = await axios.get(url);
+    if (typeof res.data === "string") {
+      return res.data;
+    }
+    throw new Error("response data is not a string");
+  } catch (e) {
+    if (e instanceof Error) {
+      console.error(`Error fetching from url: ${url}`, e.message);
+    }
+  }
+}
+
+export async function scrapeEvents() {
+  const html = await getHTML("https://uci.campusdish.com/api/events");
+  if (!html) {
+    return null;
+  }
+
+  const $ = cheerio.load(html);
+
+  const events: Event[] = [];
+
+  // iterate through each event item and extract data
+  $("li").each((i, el) => {
+    const eventItem = $(el);
+
+    const title = eventItem
+      .find(".gridItem_title_text")
+      .text();
+    const href = eventItem
+      .find("a")
+      .attr("href");
+    const link = `https://uci.campusdish.com${href}`;
+    const description = eventItem
+      .find(".gridItem__body")
+      .children()
+      .first()
+      .text();
+
+    // format into Date object
+    const dayString = eventItem
+      .find(".disclaimers")
+      .children()
+      .first()
+      .text();
+    const timeString = eventItem
+      .find(".disclaimers")
+      .children()
+      .last()
+      .text();
+    const currentYear = new Date().getFullYear();
+    const dateString = `${dayString}, ${currentYear}, ${timeString}`;
+    const date = new Date(dateString);
+
+    const event = {
+      title,
+      link,
+      description,
+      date,
+    };
+
+    const validated = EventSchema.parse(event);
+
+    events.push(validated);
+  })
+
+  return events;
+}
+
+export async function insertEvents(
+  db: PrismaClient | Prisma.TransactionClient,
+  events: Event[],
+) {
+  try {
+    // fetch existing events
+    const existingEvents = await db.event.findMany({
+      where: {
+        OR: events.map((event) => ({
+          title: event.title,
+          date: event.date,
+          link: event.link,
+        })),
+      },
+    });
+
+    // filter out existing events
+    const newEvents = events.filter(
+      (event) =>
+        !existingEvents.some(
+          (existingEvent) =>
+            existingEvent.title === event.title &&
+            existingEvent.link === event.link &&
+            new Date(existingEvent.date).getTime() === new Date(event.date).getTime()
+        )
+    );
+
+    // insert new events
+    if (newEvents.length > 0) {
+      await db.event.createMany({
+        data: newEvents,
+      });
+    }
+
+    return newEvents;
+  } catch (e) {
+    if (e instanceof Error) {
+      console.error(e);
+    }
+  }
+}

--- a/packages/db/prisma/migrations/20240215143057_/migration.sql
+++ b/packages/db/prisma/migrations/20240215143057_/migration.sql
@@ -91,6 +91,16 @@ CREATE TABLE "NutritionInfo" (
     CONSTRAINT "NutritionInfo_pkey" PRIMARY KEY ("id")
 );
 
+-- CreateTable
+CREATE TABLE "Event" (
+    "title" TEXT NOT NULL,
+    "link" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Event_pkey" PRIMARY KEY ("title","link","date")
+);
+
 -- CreateIndex
 CREATE UNIQUE INDEX "DietRestriction_dishId_key" ON "DietRestriction"("dishId");
 

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -20,7 +20,7 @@ model Dish {
 }
 
 model Restaurant {
-  id       String    @id
+  id       String         @id
   name     RestaurantName
   stations Station[]
   menu     Menu[]
@@ -45,8 +45,8 @@ enum MenuPeriod {
 }
 
 enum RestaurantName {
-    brandywine
-    anteatery
+  brandywine
+  anteatery
 }
 
 model Menu {
@@ -102,4 +102,13 @@ model NutritionInfo {
   saturatedFat       String?
   dish               Dish    @relation(fields: [dishId], references: [id])
   dishId             String  @unique
+}
+
+model Event {
+  title       String
+  link        String
+  description String
+  date        DateTime
+
+  @@id([title, link, date])
 }

--- a/packages/validators/src/zotmeal.ts
+++ b/packages/validators/src/zotmeal.ts
@@ -82,3 +82,12 @@ export const ParsedResponseSchema = z.object({
 });
 
 export type ParsedResponse = z.infer<typeof ParsedResponseSchema>;
+
+export const EventSchema = z.object({
+  title: z.string(),
+  link: z.string(),
+  description: z.string(),
+  date: z.date(),
+});
+
+export type Event = z.infer<typeof EventSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       '@zotmeal/validators':
         specifier: workspace:^
         version: link:../validators
+      cheerio:
+        specifier: 1.0.0-rc.12
+        version: 1.0.0-rc.12
       date-fns:
         specifier: ^3.3.1
         version: 3.3.1
@@ -6572,6 +6575,10 @@ packages:
     resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
     dev: false
 
+  /boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+    dev: false
+
   /bowser@2.11.0:
     resolution: {integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==}
     dev: false
@@ -6895,6 +6902,30 @@ packages:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
     dependencies:
       get-func-name: 2.0.2
+    dev: false
+
+  /cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.1.0
+      css-what: 6.1.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+    dev: false
+
+  /cheerio@1.0.0-rc.12:
+    resolution: {integrity: sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==}
+    engines: {node: '>= 6'}
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      htmlparser2: 8.0.2
+      parse5: 7.1.2
+      parse5-htmlparser2-tree-adapter: 7.0.0
     dev: false
 
   /child-process-ext@2.1.1:
@@ -7361,6 +7392,21 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /css-select@5.1.0:
+    resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.1.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      nth-check: 2.1.1
+    dev: false
+
+  /css-what@6.1.0:
+    resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
+    engines: {node: '>= 6'}
+    dev: false
+
   /cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -7700,6 +7746,33 @@ packages:
     dependencies:
       esutils: 2.0.3
 
+  /dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+    dev: false
+
+  /domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+    dev: false
+
+  /domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+    dependencies:
+      domelementtype: 2.3.0
+    dev: false
+
+  /domutils@3.1.0:
+    resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+    dev: false
+
   /dot-case@2.1.1:
     resolution: {integrity: sha512-HnM6ZlFqcajLsyudHq7LeeLDr2rFAVYtDv/hV5qchQEidSck8j9OPUsXY9KwJv/lHMtYlX4DjRQqwFYa+0r8Ug==}
     dependencies:
@@ -7762,6 +7835,11 @@ packages:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
     dependencies:
       once: 1.4.0
+    dev: false
+
+  /entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
     dev: false
 
   /env-editor@0.4.2:
@@ -9327,6 +9405,15 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       lru-cache: 6.0.0
+    dev: false
+
+  /htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      entities: 4.5.0
     dev: false
 
   /http-cache-semantics@4.1.1:
@@ -11434,6 +11521,12 @@ packages:
       path-key: 4.0.0
     dev: false
 
+  /nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+    dependencies:
+      boolbase: 1.0.0
+    dev: false
+
   /nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
     dev: false
@@ -11829,6 +11922,19 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       pngjs: 3.4.0
+    dev: false
+
+  /parse5-htmlparser2-tree-adapter@7.0.0:
+    resolution: {integrity: sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==}
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.1.2
+    dev: false
+
+  /parse5@7.1.2:
+    resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
+    dependencies:
+      entities: 4.5.0
     dev: false
 
   /parseurl@1.3.3:


### PR DESCRIPTION
## Describe your changes

Create functions to scrape events data with cheerio and batch insert the events data to db.

## Change Checklist

- [x] Create [scrapeEvents()](https://github.com/icssc/ZotMeal/blob/e5b16eb9c13d91bbcd10e042735a00788bcb9d69/packages/api/src/services/event.ts#L20) which formats & validates scraped data into [EventSchema](https://github.com/icssc/ZotMeal/blob/e5b16eb9c13d91bbcd10e042735a00788bcb9d69/packages/validators/src/zotmeal.ts#L86)
- [x] Create [insertEvents()](https://github.com/icssc/ZotMeal/blob/e5b16eb9c13d91bbcd10e042735a00788bcb9d69/packages/api/src/services/event.ts#L77) which takes in an array of events and performs a batch insert. **The caller decides whether to perform the batch insert as a transaction.**

## Verification?

- [x] Tests pass

## Notes

- Currently, events are not matched to a restaurant - it's possible, but it would require having to perform another fetch + scrape within each event item because the restaurant info is only available in the event's own page, not in the api response
- I defined the Event prisma model to have a composite key of [title, link, date]. e.g. Since the event below takes place in both anteatery and brandywine, the db will create two separate Event records because the links are different. So we're pretty much doing the same as campusdish right now but let me know if we're interested in deduplicating events like this

![image](https://github.com/icssc/ZotMeal/assets/83149801/8ef57f7d-2b3f-4c34-8517-43bfa7787383)



