### PR TITLE
Add index.ts to expo app to fix weird error running pnpm dev

### DIFF
--- a/apps/expo/index.ts
+++ b/apps/expo/index.ts
@@ -1,0 +1,1 @@
+import 'expo-router/entry';

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -2,7 +2,7 @@
   "name": "@zotmeal/expo",
   "version": "0.1.0",
   "private": true,
-  "main": "expo-router/entry",
+  "main": "index.ts",
   "scripts": {
     "clean": "git clean -xdf .expo .turbo node_modules",
     "dev": "expo start",


### PR DESCRIPTION
## Summary
Fixes an error I was having when opening `localhost:8081` after running `pnpm dev`. The site wouldn't load at all and this error would print in console:
![image](https://github.com/user-attachments/assets/50931050-94b2-441b-9b70-d5bf93467918)

## Changes
Add simple index.ts to the expo package and change main. IDK why this works or what it does, I just googled around for the error and came across a solution on this issue:
https://github.com/expo/expo/issues/28775#issuecomment-2106238484
![image](https://github.com/user-attachments/assets/8fb4c01e-56b0-4b2d-8301-5eafdca09960)

## Verification
I ran `pnpm dev` and the frontend now loads for me
![image](https://github.com/user-attachments/assets/f01502a3-9cf4-4ffb-accc-69fdb7dfdbb8)
