### PR TITLE
refactor weekly job to just run event job once

### DIFF
--- a/apps/server/src/functions/cron/weekly.ts
+++ b/apps/server/src/functions/cron/weekly.ts
@@ -1,7 +1,7 @@
 import { logger } from "logger";
 
 import { weekly } from "@zotmeal/api";
-import { createDrizzle, pool, restaurantNames } from "@zotmeal/db";
+import { createDrizzle, pool } from "@zotmeal/db";
 
 import { env } from "../env";
 import { ssl } from "../ssl";
@@ -15,24 +15,13 @@ export const main = async (_event, _context) => {
       connectionString,
       ssl,
     });
-
-    const results = await Promise.allSettled(
-      restaurantNames.map(async (restaurant) =>
-        weekly(db, new Date(), restaurant),
-      ),
-    );
-
-    // log errors if any
-    results.forEach((result) => {
-      if (result.status === "rejected")
-        logger.error("weekly() failed:", result.reason);
-    });
+    await weekly(db);
   } catch (error) {
-    logger.error(error, "Failed to execute weekly task");
+    logger.error(error, "Failed to execute weekly task.");
   } finally {
     logger.info("Closing connection pool...");
     await pool({ connectionString }).end();
     logger.info("Closed connection pool.");
-    logger.info(`✅ Finished get weekly job.`);
+    logger.info(`Finished get weekly job.`);
   }
 };

--- a/packages/api/src/apiTest.ts
+++ b/packages/api/src/apiTest.ts
@@ -22,6 +22,7 @@ interface ApiFixtures {
 
 /**
  * {@linkcode apiTest} contains fixtures for testing the service and api layers.
+ * Enable db logger to see queries.
  */
 export const apiTest = test.extend<ApiFixtures>({
   db: createDrizzle({ connectionString }, true),

--- a/packages/api/src/server/daily/daily.test.ts
+++ b/packages/api/src/server/daily/daily.test.ts
@@ -1,5 +1,4 @@
 import { apiTest } from "@api/apiTest";
-import { logger } from "@api/logger";
 import { describe } from "vitest";
 
 import { daily } from ".";

--- a/packages/api/src/server/scrapeEvents/index.ts
+++ b/packages/api/src/server/scrapeEvents/index.ts
@@ -28,10 +28,11 @@ export async function getHTML(url: string): Promise<string> {
 
 export async function scrapeEvents(html: string): Promise<Event[]> {
   try {
+    logger.info(`scrapeEvents: Scraping events...`);
     const $ = cheerio.load(html);
 
     // iterate through each event item and extract data
-    return await Promise.all(
+    const events = await Promise.all(
       $("li").map(async (_, element) => {
         const eventItem = $(element);
 
@@ -93,8 +94,12 @@ export async function scrapeEvents(html: string): Promise<Event[]> {
         return event;
       }),
     );
+
+    logger.info(`scrapeEvents: ✅ Scraped ${events.length} events.`);
+
+    return events;
   } catch (error) {
-    console.error(`Error scraping events: ${error}`);
+    console.error(`scrapeEvents: ❌ Error scraping events: ${error}`);
     throw error;
   }
 }

--- a/packages/api/src/server/weekly/index.ts
+++ b/packages/api/src/server/weekly/index.ts
@@ -3,37 +3,66 @@ import { logger } from "@api/logger";
 import { addDays, format } from "date-fns";
 
 import type { Drizzle, RestaurantName } from "@zotmeal/db";
+import { restaurantNames } from "@zotmeal/db";
 
 import { daily } from "../daily";
 import { getHTML, scrapeEvents } from "../scrapeEvents";
 
 const NUM_DAYS_UPDATE = 14;
 
-export async function weekly(
-  db: Drizzle,
-  date: Date,
-  restaurant: RestaurantName,
-): Promise<void> {
-  // scrape and upsert current events
+/**
+ * Scrape and upsert events from CampusDish.
+ * The endpoint contains events from both restaurants.
+ */
+export async function eventJob(db: Drizzle): Promise<void> {
   const html = await getHTML(
     "https://uci-campusdish-com.translate.goog/api/events?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp",
   );
   const events = await scrapeEvents(html);
-  await upsertEvents(db, events);
 
-  // Update menus for each day
+  logger.info(`weekly: Upserting ${events.length} events...`);
+  const upsertedEvents = await upsertEvents(db, events);
+  logger.info(`weekly: Upserted ${upsertedEvents.length} events.`);
+}
+
+/**
+ * Executes a {@link daily} job {@link NUM_DAYS_UPDATE} days out starting from the given date.
+ */
+export async function restaurantJob(
+  db: Drizzle,
+  date: Date,
+  restaurant: RestaurantName,
+): Promise<void> {
+  await eventJob(db);
+
   const results = await Promise.allSettled(
     Array.from({ length: NUM_DAYS_UPDATE }).map((_, i) =>
       daily(db, addDays(date, i), restaurant),
     ),
   );
 
-  // log errors from the promises
+  // Log errors.
   results.forEach((result, i) => {
     if (result.status === "rejected")
       logger.error(
         result,
         `weekly: Error updating day ${format(addDays(date, i), "yyyy-MM-dd")}:`,
       );
+  });
+}
+
+export async function weekly(db: Drizzle): Promise<void> {
+  await eventJob(db);
+
+  const results = await Promise.allSettled(
+    restaurantNames.map(async (restaurant) =>
+      restaurantJob(db, new Date(), restaurant),
+    ),
+  );
+
+  // Log errors.
+  results.forEach((result) => {
+    if (result.status === "rejected")
+      logger.error("weekly() failed:", result.reason);
   });
 }

--- a/packages/api/src/server/weekly/weekly.test.ts
+++ b/packages/api/src/server/weekly/weekly.test.ts
@@ -1,7 +1,24 @@
 import { apiTest } from "@api/apiTest";
 import { describe } from "vitest";
 
-// TODO
+import { weekly } from ".";
+
+// TODO: runs too slow, tried it on local db and on test container
 describe("weekly", () => {
-  apiTest.todo("populates db with menus for the week");
+  apiTest.skip(
+    "populates db with menus and events",
+    async ({ expect, db }) => {
+      await expect(
+        db.transaction(async (trx) => {
+          await weekly(trx);
+          const menus = await trx.query.menus.findMany();
+          expect(menus.length).toBeGreaterThan(0);
+          const events = await trx.query.events.findMany();
+          expect(events.length).toBeGreaterThan(0);
+          trx.rollback();
+        }),
+      ).rejects.toThrowError("Rollback");
+    },
+    { timeout: 600_000 },
+  );
 });


### PR DESCRIPTION
## Summary

also just simplifies the weekly cronjob into a function call

## Changes

- [x] refactor weekly job to just run event job once
- [x] add weekly test

## Verification

- [x] passes manual test, events show up in client. automated test doesn't work, runs too slow (the queries become transactional so it slows down)
