### PR TITLE
:card_file_box: Add new field and composite primary key 'date'

### DIFF
--- a/packages/api/src/periods/services.ts
+++ b/packages/api/src/periods/services.ts
@@ -5,6 +5,6 @@ import { periods } from "@zotmeal/db";
 
 export const upsertPeriod = async (db: Drizzle, period: InsertPeriod) =>
   await upsert(db, periods, period, {
-    target: periods.id,
+    target: [periods.id, periods.date],
     set: period,
   });

--- a/packages/api/src/server/daily/parse.ts
+++ b/packages/api/src/server/daily/parse.ts
@@ -219,6 +219,8 @@ export async function upsertMenusForDate(
     periodsMap[periodObj.PeriodId] = 
       [periodObj.UtcMealPeriodStartTime, periodObj.UtcMealPeriodEndTime];
   });
+  
+  const formattedDateForDb = format(date, "yyyy-MM-dd");
 
 
   // Upsert all periods and menus for the given date 
@@ -229,6 +231,7 @@ export async function upsertMenusForDate(
 
       await upsertPeriod(db, {
         id: period.PeriodId,
+        date: formattedDateForDb,
         name: period.Name,
         startTime: periodInfo![0],
         endTime: periodInfo![1],
@@ -250,7 +253,7 @@ export async function upsertMenusForDate(
       await upsertMenu(db, {
         id: menuIdHash,
         periodId: period.PeriodId,
-        date: menuAtDate.Date,
+        date: formattedDateForDb,
         price: "13.75", // TODO: add menu price to response
         restaurantId,
       });

--- a/packages/db/src/schema/periods.ts
+++ b/packages/db/src/schema/periods.ts
@@ -1,14 +1,17 @@
-import { pgTable, text, time } from "drizzle-orm/pg-core";
+import { pgTable, text, time, date, primaryKey } from "drizzle-orm/pg-core";
 
 import { metadataColumns } from "./utils";
 
 export const periods = pgTable("periods", {
-  id: text("id").primaryKey(),
+  id: text("id").notNull(),
+  date: date("date").notNull(),
   startTime: time("start").notNull(),
   endTime: time("end").notNull(),
   name: text("name").notNull(),
   ...metadataColumns,
-});
+}, (table) => ({ 
+  pk: primaryKey({ columns: [table.id, table.date] })
+}));
 
 /** A meal period, e.g. breakfast. */
 export type InsertPeriod = typeof periods.$inferInsert;


### PR DESCRIPTION
## Summary
Adds a new field to the periods table of our database. This allows us to view periods of days in the future and prevents misinformation of periods from other days.

## Changes
- [ ] The periods table no longer has id as a primary key.
- [ ] The periods table now has a column `date` with type `date`, corresponding to the date of that period.
- [ ] The periods table primary key is now a composite key of id and date.

Closes #497 