### PR TITLE
✨Add ingredients field, fix sub-nutrition, fix sugar

### DIFF
--- a/apps/next/src/components/ingredients-dialog.tsx
+++ b/apps/next/src/components/ingredients-dialog.tsx
@@ -1,0 +1,27 @@
+import { Dialog, DialogTrigger, DialogContent, DialogTitle } from "./ui/shadcn/dialog"
+import { Button } from "./ui/shadcn/button"
+
+interface IngredientsDialogProps {
+  name: string,
+  ingredients: string
+}
+
+export default function IngredientsDialog({name, ingredients} : IngredientsDialogProps) : JSX.Element {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full"
+        >
+          Show All Ingredients
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogTitle className="px-5 pt-5">{name} Ingredients</DialogTitle>
+        <p className="px-5 text-sm max-h-48 overflow-y-scroll">{ingredients}</p>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/next/src/components/ui/card/food-card.tsx
+++ b/apps/next/src/components/ui/card/food-card.tsx
@@ -30,18 +30,18 @@ const FoodCardContent = React.forwardRef<
                 <strong>{formatFoodName(dish.name)}</strong>
                 <div className="flex gap-2 items-center">
                   <span>{dish.nutritionInfo.calories == null ? "-" : `${dish.nutritionInfo.calories} cal`}</span>
-                  <div className="flex gap-1 items-center">
+                  {/* <div className="flex gap-1 items-center">
                     <Star className="w-4 stroke-zinc-400 stroke-2"></Star>
                     <span className="text-zinc-400 text-sm text-center">
                       {4.5} ({100})
                     </span>
-                  </div>
+                  </div> */}
                 </div>
               </div>
             </div>
-            <div className="flex flex-col justify-center">
+            {/* <div className="flex flex-col justify-center">
               <Star className="w-8 h-8 stroke-zinc-400"></Star>
-            </div>
+            </div> */}
           </div>
         </CardContent>
       </Card>

--- a/apps/next/src/components/ui/food-dialog-content.tsx
+++ b/apps/next/src/components/ui/food-dialog-content.tsx
@@ -18,7 +18,7 @@ import IngredientsDialog from "../ingredients-dialog";
 export default function FoodDialogContent(dish: DishInfo) {
   // State to control nutrient visibility
   const [showAllNutrients, setShowAllNutrients] = useState(false);
-  const initialNutrients = ['calories', 'totalFatG', 'totalCarbsG', 'proteinG', 'sugarsMg']; // Define which nutrients to show initially
+  const initialNutrients = ['calories', 'totalFatG', 'totalCarbsG', 'proteinG', 'sugarsG']; // Define which nutrients to show initially
   const recognizedNutrients = initialNutrients.concat(['transFatG', 'saturatedFatG', 'cholesterolMg', 'sodiumMg', 'calciumMg', 'ironMg'])
 
   const ingredientsAvailable: boolean = dish.ingredients != "Ingredient Statement Not Available";

--- a/apps/next/src/components/ui/food-dialog-content.tsx
+++ b/apps/next/src/components/ui/food-dialog-content.tsx
@@ -11,6 +11,8 @@ import { formatFoodName, formatNutrientLabel } from "@/utils/funcs";
 import { DishInfo } from "@zotmeal/api";
 import { toTitleCase, enhanceDescription } from "@/utils/funcs";
 import { AllergenBadge } from "./allergen-badge";
+import { Dialog, DialogTrigger } from "@radix-ui/react-dialog";
+import IngredientsDialog from "../ingredients-dialog";
 
 
 export default function FoodDialogContent(dish: DishInfo) {
@@ -18,6 +20,8 @@ export default function FoodDialogContent(dish: DishInfo) {
   const [showAllNutrients, setShowAllNutrients] = useState(false);
   const initialNutrients = ['calories', 'totalFatG', 'totalCarbsG', 'proteinG', 'sugarsMg']; // Define which nutrients to show initially
   const recognizedNutrients = initialNutrients.concat(['transFatG', 'saturatedFatG', 'cholesterolMg', 'sodiumMg', 'calciumMg', 'ironMg'])
+
+  const ingredientsAvailable: boolean = dish.ingredients != "Ingredient Statement Not Available";
 
   return (
     <DialogContent>
@@ -34,15 +38,15 @@ export default function FoodDialogContent(dish: DishInfo) {
             <div className="flex gap-12 px-4 items-center" id="food-header-info">
               <div className="flex gap-3 items-center">
                 <DialogTitle className="text-3xl">{formatFoodName(dish.name)}</DialogTitle>
-                <Pin className="stroke-zinc-500"/>
+                {/* <Pin className="stroke-zinc-500"/> */}
               </div>
-              <div className="flex gap-2">
+              {/* <div className="flex gap-2">
                 <Star className="stroke-zinc-500" size={26}/>
                 <Star className="stroke-zinc-500" size={26}/>
                 <Star className="stroke-zinc-500" size={26}/>
                 <Star className="stroke-zinc-500" size={26}/>
                 <Star className="stroke-zinc-500" size={26}/>
-              </div>
+              </div> */}
             </div>
             <div className="px-4 flex items-center gap-2 text-zinc-500">
               <span>{dish.nutritionInfo.calories == null ? "-" : `${dish.nutritionInfo.calories} cal`} • {toTitleCase(dish.restaurant)}</span>
@@ -78,7 +82,7 @@ export default function FoodDialogContent(dish: DishInfo) {
                     );
                   })}
               </div>
-              <div className="px-4">
+              <div className="px-4 flex flex-col gap-2">
                 <Button
                   variant="outline"
                   size="sm"
@@ -87,6 +91,12 @@ export default function FoodDialogContent(dish: DishInfo) {
                 >
                   {showAllNutrients ? "Show Less" : "Show More Nutrients"}
                 </Button>
+                {ingredientsAvailable &&
+                  <IngredientsDialog name={dish.name} ingredients={dish.ingredients!}/>
+                }
+                {!ingredientsAvailable &&
+                  <Button variant="deactivated">Ingredients Not Available</Button>
+                }
               </div>
             </div>
           </div>

--- a/apps/next/src/utils/types.ts
+++ b/apps/next/src/utils/types.ts
@@ -52,7 +52,7 @@ const nutrientToUnit : { [nutrient: string]: string } = {
   "sodiumMg": "mg",
   "totalCarbsG": "g",
   "dietaryFiberG": "g",
-  "sugarsMg": "mg",
+  "sugarsG": "g",
   "proteinG": "g",
   "vitaminAIU": "% DV",
   "vitaminCIU": "% DV",

--- a/packages/api/src/server/daily/parse.ts
+++ b/packages/api/src/server/daily/parse.ts
@@ -293,6 +293,7 @@ export async function upsertMenusForDate(
               containsWheat: menuProduct.Product.AvailableFilters.ContainsWheat,
               containsSesame: menuProduct.Product.AvailableFilters.ContainsSesame,
             },
+            ingredients: menuProduct.Product.IngredientStatement,
             nutritionInfo: {
               dishId: menuProduct.ProductId,
               servingSize: menuProduct.Product.ServingSize,

--- a/packages/api/src/server/daily/parse.ts
+++ b/packages/api/src/server/daily/parse.ts
@@ -306,15 +306,8 @@ export async function upsertMenusForDate(
               sodiumMg: nutritionalInfo["Sodium"],
               totalCarbsG: nutritionalInfo["Total Carbohydrates"],
               dietaryFiberG: nutritionalInfo["Dietary Fiber"],
-              // TODO: Sugars are now listed in grams
-              sugarsMg: nutritionalInfo["Sugar"],
+              sugarsG: nutritionalInfo["Total Sugars"],
               proteinG: nutritionalInfo["Protein"],
-              // TODO: The following dish information is no longer offered 
-              // as of 5/15/2025
-              vitaminAIU: null,
-              vitaminCIU: null,
-              calciumMg: null,
-              ironMg: null,
             },
           });
 

--- a/packages/api/src/server/daily/parse.ts
+++ b/packages/api/src/server/daily/parse.ts
@@ -270,7 +270,7 @@ export async function upsertMenusForDate(
 
             if (nutrition.SubList != null && nutrition.SubList.length > 0) {
               nutrition.SubList.forEach(subNutrition => {
-                nutritionalInfo[subNutrition!.Name] = nutrition.Value;
+                nutritionalInfo[subNutrition!.Name] = subNutrition.Value;
               })
             }
           });

--- a/packages/db/src/schema/dishes.ts
+++ b/packages/db/src/schema/dishes.ts
@@ -17,6 +17,7 @@ export const dishes = pgTable("dishes", {
     }),
   name: text("name").notNull(),
   description: text("description").notNull(),
+  ingredients: text("ingredients").default("Ingredient Statement Not Available"),
   /** Defaults to "Other" if not specified. */
   category: text("category").notNull().default("Other"),
   numRatings: integer("num_ratings").default(0).notNull(),

--- a/packages/db/src/schema/nutritionInfos.ts
+++ b/packages/db/src/schema/nutritionInfos.ts
@@ -20,12 +20,8 @@ export const nutritionInfos = pgTable("nutrition_infos", {
   sodiumMg: text("sodium_mg"),
   totalCarbsG: text("total_carbs_g"),
   dietaryFiberG: text("dietary_fiber_g"),
-  sugarsMg: text("sugars_mg"),
+  sugarsG: text("sugars_g"),
   proteinG: text("protein_g"),
-  vitaminAIU: text("vitamin_a_iu"),
-  vitaminCIU: text("vitamin_c_iu"),
-  calciumMg: text("calcium_mg"),
-  ironMg: text("iron_mg"),
   ...metadataColumns,
 });
 

--- a/packages/validators/src/campusdish/models.ts
+++ b/packages/validators/src/campusdish/models.ts
@@ -31,6 +31,7 @@ export const MenuProductSchema = z.object({
       ContainsTreeNuts: z.boolean().nullable().optional(),
       ContainsWheat: z.boolean().nullable().optional(),
     }),
+    IngredientStatement: z.string(),
     // Nutrition Info object
     NutritionalTree: z.array(
       z.object({


### PR DESCRIPTION
## Summary
Add an ingredients field to the dish table, fix subnutrition values incorrectly taking on their parent nutrition values, fix sugars not being displayed at all

## Changes
- [ ] Adds an ingredients `text` field to the dish table. If not available, defaults to `Ingredients Statement Not Available`, upon which it is not rendered on the front end.
- [ ] Adds an `ingredients-dialog.tsx` to the dish dialog.
- [ ] Subnutrition (trans fat, sat fat) no longer incorrectly takes on the values of the parent nutritional value.
- [ ] Sugars were incorrectly always appearing as null due to a key error; this is fixed.
- [ ] Removes empty fields no longer offered by the CampusDish API

Closes #498 
Closes #510 