### PR TITLE
fix(ci): set timezone to America/Los_Angeles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set timezone
+        run: sudo timedatectl set-timezone "America/Los_Angeles"
+
       - name: Setup
         uses: ./tooling/github/setup
 


### PR DESCRIPTION
This PR sets the runner's timezone in the CI workflow to resolve the 8 hour offset issue. Ensures tests and builds run in the same timezone as production.

Closes #530 
