### PR TITLE
fix(test:daily): file path formatting

### DIFF
--- a/packages/api/src/server/daily/parse.ts
+++ b/packages/api/src/server/daily/parse.ts
@@ -72,7 +72,7 @@ export async function queryAdobeECommerce(
     };
 
     if (process.env.IS_LOCAL) {
-      const outPath = `query-${new Date().toISOString()}-response.json`
+      const outPath = `query-${new Date().toISOString().replace(/:/g, '-')}-response.json`;
       writeFileSync(`./${outPath}`, JSON.stringify(loggedResponse), { flag: "w" });
       logger.info(`[query] Wrote AdobeEcommerce response to ${process.cwd()}/${outPath}.`);
     }


### PR DESCRIPTION
## Summary
Windows 11 does not allow the colon `:` in its filepaths. The time stamp created by new Date().toISOString() contains colons, which caused the test:daily job to fail on my computer due to errors with the filepath.

## Changes
- [x] Replace the colon(s) in the timestamp with dashes.

## Verification
- [x] Ran `pnpm run test:daily` locally on Windows and confirmed the process completes without the `ENOENT` crash.

Closes # N/A (no assigned issue)
