### PR TITLE
feat: :sparkles: date selection restriction (#545) [merge from dev]

### DIFF
--- a/apps/next/src/components/ui/shadcn/date-picker.tsx
+++ b/apps/next/src/components/ui/shadcn/date-picker.tsx
@@ -11,15 +11,23 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "./popover"
+import type { CalendarRange } from "../toolbar"
+import { isSameDay } from "@/utils/funcs"
+import { DateList } from "../../../../../../packages/db/src/schema"
 
-export function DatePicker({date, onSelect} : {date: Date | undefined, onSelect: (newDateFromPicker : Date | undefined) => void}) {
+export function DatePicker({date, enabledDates, range, onSelect} : {
+    date: Date | undefined,
+    enabledDates: DateList,
+    range: CalendarRange,
+    onSelect: (newDateFromPicker : Date | undefined) => void
+}) {
   return (
     <Popover>
       <PopoverTrigger asChild>
         <Button
           variant={"ghost"}
           className={cn(
-            "justify-start text-left font-normal px-2",
+            "w-full justify-start text-left font-normal",
             !date && "text-muted-foreground"
           )}
         >
@@ -33,6 +41,13 @@ export function DatePicker({date, onSelect} : {date: Date | undefined, onSelect:
           selected={date}
           onSelect={onSelect}
           initialFocus
+          fromDate={range.earliest}
+          toDate={range.latest}
+          disabled={(d) => 
+            (date ? isSameDay(d, date) : true)
+            || !enabledDates?.some(
+              ed => ed.getTime() === d.getTime()
+          )}
         />
       </PopoverContent>
     </Popover>

--- a/apps/next/src/components/ui/toolbar.tsx
+++ b/apps/next/src/components/ui/toolbar.tsx
@@ -6,6 +6,15 @@ import { Sheet, SheetTrigger } from "./shadcn/sheet";
 import SidebarContent from "./sidebar/sidebar-content";
 import { DatePicker } from "./shadcn/date-picker";
 import { useDate } from "@/context/date-context";
+import { trpc } from "@/utils/trpc"; // Import tRPC hook
+import { useEffect, useState } from "react";
+import { DateList } from "../../../../../packages/db/src/schema";
+
+/** Dates to restrict calendar navigation. */
+export type CalendarRange = {
+  earliest: Date,
+  latest: Date,
+}
 
 /**
  * Renders the main toolbar for the application.
@@ -22,13 +31,30 @@ import { useDate } from "@/context/date-context";
  */
 export default function Toolbar(): JSX.Element {
   const { selectedDate, setSelectedDate } = useDate();
+  const [enabledDates, setEnabledDates] = useState<DateList>([new Date()]);  // default: enable today
+  const [calendarRange, setCalendarRange] = useState<CalendarRange>({
+    earliest: new Date(),
+    latest: new Date(),
+  });  // default: restrict to today
+
+  const { data: dateRes } = trpc.pickableDates.useQuery()
+  
+  useEffect(() => {
+    if (dateRes) {
+      setEnabledDates(dateRes);
+      setCalendarRange({
+        earliest: dateRes[0],
+        latest: dateRes[dateRes.length-1]
+      });
+    }
+  }, [dateRes])
 
   /**
    * Handles the date selection event from the `DatePicker` component.
    *
    * This function updates the `selectedDate` in the `DateContext`.
    * - If the `newDateFromPicker` is the current calendar day ("today"),
-   *   `selectedDate` is set to the current date *and time* (i.e., `new Date()`).
+   *   `selectedDate` is set to the current date and time (i.e., `new Date()`).
    *   This ensures that any application logic relying on the current time of day
    *   (e.g., determining if a dining hall is currently open) operates correctly.
    * - If `newDateFromPicker` is a day other than today (past or future),
@@ -80,6 +106,8 @@ export default function Toolbar(): JSX.Element {
             <DatePicker
               date={selectedDate}
               onSelect={handleDateSelect}
+              enabledDates={enabledDates}
+              range={calendarRange}
             />
             <SheetTrigger asChild>
               <Button variant="ghost" size="icon">

--- a/packages/api/src/menus/services.test.ts
+++ b/packages/api/src/menus/services.test.ts
@@ -1,9 +1,9 @@
 import { apiTest } from "@api/apiTest";
 import { upsertPeriod } from "@api/periods/services";
 import { upsertRestaurant } from "@api/restaurants/services";
-import { describe } from "vitest";
+import { describe, it } from "vitest";
 
-import { upsertMenu } from "./services";
+import { getPickableDates, upsertMenu } from "./services";
 
 describe("upsertMenu", () => {
   apiTest("inserts valid menu into db", async ({ expect, db, testData }) => {
@@ -33,3 +33,19 @@ describe("upsertMenu", () => {
     ).rejects.toThrowError("Rollback");
   });
 });
+
+describe("getDateList", () => {
+  apiTest("gets list of pickable dates", async ({ expect, db }) => {
+    const res = await getPickableDates(db);
+    if (res) {
+      res.forEach(d => {
+        expect(d).toBeInstanceOf(Date);
+      })
+
+      // check dates are unique and asc
+      for (let i = 1; i < res.length; i++)
+        expect(res[i]!.getTime())
+          .toBeGreaterThan(res[i - 1]!.getTime());
+    }
+  });
+})

--- a/packages/api/src/root.ts
+++ b/packages/api/src/root.ts
@@ -8,6 +8,7 @@ import { getRestaurantsByDate } from "./restaurants/services";
 import { createTRPCRouter, publicProcedure } from "./trpc";
 import { userRouter } from "./users/router";
 import { getContributors } from "./contributors/services";
+import { getPickableDates } from "./menus/services";
 
 export const appRouter = createTRPCRouter({
   event: eventRouter,
@@ -24,6 +25,17 @@ export const appRouter = createTRPCRouter({
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: "An error occurred while fetching restaurants",
+        });
+      }),
+  ),
+  /** Get earliest and latest days we currently have meal info for. */
+  pickableDates: publicProcedure.query(
+    async ({ctx: { db }}) => 
+      await getPickableDates(db).catch((error) => {
+        if (error instanceof TRPCError) throw error;
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "An error occurred while fetching dates with meal information."
         });
       }),
   ),

--- a/packages/db/src/schema/menus.ts
+++ b/packages/db/src/schema/menus.ts
@@ -78,3 +78,5 @@ export type InsertMenu = typeof menus.$inferInsert;
 export type SelectMenu = typeof menus.$inferSelect;
 /** A join between a dish and a menu. */
 export type DishToMenu = typeof dishesToMenus.$inferInsert;
+/** List of dates we have menu data for. */
+export type DateList = Date[] | null;


### PR DESCRIPTION
* wip: event images

* feat(api): add image fetching logic to weeklyJob

* fix(api): uncomment contributors and weekly job

* perf(api/weekly): add batch updates for menus and dishes in weekly

* feat(api): get date range trpc query

* chore(api): getDateRange test

* feat(frontend): restrict pickable dates on calendar

* fix(api): convert Y-M-D date string to local time

* fix(frontend): date picker button fits date

* fix(frontend): cannot select already selected date

* feat(api): get list instead of range of pickable dates

* feat(frontend): user selects from list of enabled dates

* feat(frontend): restrict calendar navigation to pickable dates

* fix(api): error msg and db sorting logic

* chore(frontend): removed dup DateList type definition

---------

## Summary
(Write a small summary of the implemented changes in this pull request)

## Changes
- [ ]

### Testing Instructions
(Write a small list of instructions necessary to test the code on this branch. 
If you do not need to change anything locally from main in order to test this branch, 
omit these instructions.) 

Closes #
