### PR TITLE
fix: await upsert in weekly

### DIFF
--- a/packages/api/src/server/weekly/upsert.ts
+++ b/packages/api/src/server/weekly/upsert.ts
@@ -128,7 +128,7 @@ export async function upsertMenusForWeek(
 
   if (dishesToUpsert.length > 0) {
     logger.info(`[weekly] Upserting ${dishesToUpsert.length} dishes...`);
-    Promise.allSettled(
+    await Promise.allSettled(
       dishesToUpsert.map(async d =>
         await parseAndUpsertDish(db, 
           restaurantInfo, 


### PR DESCRIPTION
## Summary
Not awaiting the `Promise.all` results in the database connection closing prematurely, losing data from the scrape.

## Changes
- [ ]

### Testing Instructions
(Write a small list of instructions necessary to test the code on this branch. 
If you do not need to change anything locally from main in order to test this branch, 
omit these instructions.) 

Closes #
