### PR TITLE
601/meal images

### DIFF
--- a/apps/next/src/components/ui/card/food-card.tsx
+++ b/apps/next/src/components/ui/card/food-card.tsx
@@ -6,6 +6,7 @@ import { DishInfo } from "@zotmeal/api";
 import { formatFoodName, getFoodIcon, toTitleCase } from "@/utils/funcs";
 import { cn } from "@/utils/tw";
 import { Dialog, Card, CardContent, Drawer } from "@mui/material";
+import Image from "next/image";
 import FoodDialogContent from "../food-dialog-content";
 import { CirclePlus, Heart, Star, Utensils } from "lucide-react";
 import FoodDrawerContent from "../food-drawer-content";
@@ -55,6 +56,9 @@ const FoodCardContent = React.forwardRef<HTMLDivElement, FoodCardContentProps>(
     ref,
   ) => {
     const IconComponent = getFoodIcon(dish.name) ?? Utensils;
+    // Backend weekly job and shared types use `image` for media URLs; support it here.
+    const image =
+      (dish as DishInfo & { image?: string | null }).image ?? null;
 
     /**
      * Fetches the average rating and rating count for the dish.
@@ -81,7 +85,7 @@ const FoodCardContent = React.forwardRef<HTMLDivElement, FoodCardContentProps>(
         alert(`Added ${formatFoodName(dish.name)} to your log`);
         utils.nutrition.invalidate();
       },
-      onError: (error: Error) => {
+      onError: (error) => {
         console.error(error.message);
       },
     });
@@ -122,8 +126,18 @@ const FoodCardContent = React.forwardRef<HTMLDivElement, FoodCardContentProps>(
           <CardContent sx={{ padding: "0 !important" }}>
             <div className="flex justify-between h-full p-6">
               <div className="flex items-center gap-6 w-full">
-                {IconComponent && (
-                  <IconComponent className="w-10 h-10 text-slate-700" />
+                {image ? (
+                  <Image
+                    src={image}
+                    alt={formatFoodName(dish.name)}
+                    width={40}
+                    height={40}
+                    className="w-10 h-10 rounded-full object-cover"
+                  />
+                ) : (
+                  IconComponent && (
+                    <IconComponent className="w-10 h-10 text-slate-700" />
+                  )
                 )}
                 <div className="flex flex-col">
                   <strong>{formatFoodName(dish.name)}</strong>

--- a/apps/next/src/components/ui/food-dialog-content.tsx
+++ b/apps/next/src/components/ui/food-dialog-content.tsx
@@ -9,12 +9,14 @@ import {
   formatFoodName,
   formatNutrientLabel,
   formatNutrientValue,
+  getFoodIcon,
 } from "@/utils/funcs";
 import { DishInfo } from "@zotmeal/api";
 import { toTitleCase, enhanceDescription } from "@/utils/funcs";
 import { AllergenBadge } from "./allergen-badge";
 import IngredientsDialog from "../ingredients-dialog";
 import InteractiveStarRating from "./interactive-star-rating";
+import { Utensils } from "lucide-react";
 
 /**
  * `FoodDialogContent` renders the detailed view of a food item (dish) within a dialog.
@@ -53,15 +55,25 @@ export default function FoodDialogContent(dish: DishInfo): React.JSX.Element {
     dish.nutritionInfo.calories != null &&
     dish.nutritionInfo.calories.length > 0;
 
+  // Meal images are exposed as `image` on the dish object.
+  const { image } = dish as DishInfo & { image?: string | null };
+  const IconComponent = getFoodIcon(dish.name) ?? Utensils;
+
   return (
     <>
-      <Image
-        src={"/zm-card-header.webp"}
-        alt={"An image of zotmeal logo."}
-        width={1200}
-        height={700}
-        className="w-full h-40 object-cover"
-      />
+      {image ? (
+        <Image
+          src={image}
+          alt={formatFoodName(dish.name)}
+          width={1200}
+          height={700}
+          className="w-full h-40 object-cover"
+        />
+      ) : (
+        <div className="w-full h-40 flex items-center justify-center bg-slate-100">
+          <IconComponent className="w-12 h-12 text-slate-700" />
+        </div>
+      )}
       <div className="max-w-lg mx-auto w-full">
         <DialogContent sx={{ padding: "0 !important" }}>
           <div className="flex flex-col gap-6 pb-6 pt-4">

--- a/apps/next/src/components/ui/food-drawer-content.tsx
+++ b/apps/next/src/components/ui/food-drawer-content.tsx
@@ -1,7 +1,7 @@
 "use client"; // Need state for toggling nutrient visibility
 
 import { Button, Box } from "@mui/material";
-import { Pin } from "lucide-react";
+import { Pin, Utensils } from "lucide-react";
 import Image from "next/image";
 import React, { useState } from "react";
 import { cn } from "@/utils/tw";
@@ -10,6 +10,7 @@ import {
   formatFoodName,
   formatNutrientLabel,
   formatNutrientValue,
+  getFoodIcon,
 } from "@/utils/funcs";
 import { DishInfo } from "@zotmeal/api";
 import { toTitleCase, enhanceDescription } from "@/utils/funcs";
@@ -39,16 +40,26 @@ export default function FoodDrawerContent(dish: DishInfo): React.JSX.Element {
     "ironMg",
   ]);
 
+  // Meal images are exposed as `image` on the dish object.
+  const { image } = dish as DishInfo & { image?: string | null };
+  const IconComponent = getFoodIcon(dish.name) ?? Utensils;
+
   return (
     <Box className="max-h-[95vh] flex flex-col">
       <Box className="pb-4">
-        <Image
-          src={"/zm-card-header.webp"}
-          alt={"An image of zotmeal logo."}
-          width={1200}
-          height={700}
-          className="w-full h-32 object-cover"
-        />
+        {image ? (
+          <Image
+            src={image}
+            alt={formatFoodName(dish.name)}
+            width={1200}
+            height={700}
+            className="w-full h-32 object-cover"
+          />
+        ) : (
+          <Box className="w-full h-32 flex items-center justify-center bg-slate-100">
+            <IconComponent className="w-12 h-12 text-slate-700" />
+          </Box>
+        )}
         <Box className="px-4 pt-4 flex flex-col gap-2">
           <div className="flex items-center justify-between">
             <h2 className="text-3xl font-semibold leading-tight tracking-normal">


### PR DESCRIPTION
## Changes
- Display meal image on food cards, dialog and drawer with icon fallback
- Currently only displays the icon fallback because meals don't have their images

Closes #601 
