### PR TITLE
fix: remove duplicate children from layout-client

### DIFF
--- a/apps/next/src/app/layout-client.tsx
+++ b/apps/next/src/app/layout-client.tsx
@@ -66,7 +66,6 @@ export function RootClient({ children }: { children: React.ReactNode }) {
         <QueryClientProvider client={queryClient}>
           <DateProvider>
             <Toolbar />
-            {children}
             <GlobalSnackbar />
             {/* Extra spacing for mobile view so toolbar doesn't overlap content */}
             <main className="pb-20 md:pb-0">{children}</main>


### PR DESCRIPTION
I noticed that on each staging instance, each page would show twice, probably caused by a flook in merge conflict resolving.

Removed the duplicate `{children}` in `layout-client.tsx`.
