### PR TITLE
fix: 🐛 themes on refresh and logout login

### DIFF
--- a/apps/next/src/components/theme-provider.tsx
+++ b/apps/next/src/components/theme-provider.tsx
@@ -7,36 +7,40 @@ import {
   StyledEngineProvider,
 } from "@mui/material/styles";
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v14-appRouter";
-import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes";
+import { useMemo } from "react";
 import resolveConfig from "tailwindcss/resolveConfig";
 import tailwindConfig from "../../tailwind.config";
 
 const twColors = resolveConfig(tailwindConfig).theme.colors;
 
-const theme = createTheme({
-  cssVariables: {
-    colorSchemeSelector: "class",
-  },
-  colorSchemes: {
-    light: {
-      palette: {
-        primary: {
-          main: twColors.sky["700"],
+function MuiThemeWrapper({ children }: { children: React.ReactNode }) {
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
+
+  const theme = useMemo(
+    () =>
+      createTheme({
+        palette: {
+          mode: isDark ? "dark" : "light",
+          primary: {
+            main: isDark ? twColors.sky["800"] : twColors.sky["700"],
+          },
         },
-      },
-    },
-    dark: {
-      palette: {
-        primary: {
-          main: twColors.sky["800"],
+        typography: {
+          fontFamily: "var(--font-poppins), sans-serif",
         },
-      },
-    },
-  },
-  typography: {
-    fontFamily: "var(--font-poppins), sans-serif",
-  },
-});
+      }),
+    [isDark],
+  );
+
+  return (
+    <MUIThemeProvider theme={theme}>
+      <CssBaseline />
+      {children}
+    </MUIThemeProvider>
+  );
+}
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   return (
@@ -47,10 +51,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
           defaultTheme="system"
           enableSystem
         >
-          <MUIThemeProvider theme={theme}>
-            <CssBaseline />
-            {children}
-          </MUIThemeProvider>
+          <MuiThemeWrapper>{children}</MuiThemeWrapper>
         </NextThemesProvider>
       </AppRouterCacheProvider>
     </StyledEngineProvider>

--- a/apps/next/src/components/theme-provider.tsx
+++ b/apps/next/src/components/theme-provider.tsx
@@ -5,10 +5,11 @@ import {
   createTheme,
   ThemeProvider as MUIThemeProvider,
   StyledEngineProvider,
+  useColorScheme,
 } from "@mui/material/styles";
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v14-appRouter";
 import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import resolveConfig from "tailwindcss/resolveConfig";
 import tailwindConfig from "../../tailwind.config";
 
@@ -16,16 +17,22 @@ const twColors = resolveConfig(tailwindConfig).theme.colors;
 
 function MuiThemeWrapper({ children }: { children: React.ReactNode }) {
   const { resolvedTheme } = useTheme();
-  const isDark = resolvedTheme === "dark";
+  const { setMode } = useColorScheme();
+  const [mounted, setMounted] = useState(false);
+
+  // Sync next-themes state to MUI internal state
+  useEffect(() => {
+    setMounted(true);
+    if (resolvedTheme) {
+      setMode(resolvedTheme as "light" | "dark");
+    }
+  }, [resolvedTheme, setMode]);
 
   const theme = useMemo(
     () =>
       createTheme({
         cssVariables: {
           colorSchemeSelector: "class",
-        },
-        palette: {
-          mode: isDark ? "dark" : "light",
         },
         colorSchemes: {
           light: {
@@ -56,11 +63,16 @@ function MuiThemeWrapper({ children }: { children: React.ReactNode }) {
           fontFamily: "var(--font-poppins), sans-serif",
         },
       }),
-    [isDark],
+    [],
   );
 
+  if (!mounted) return null;
+
   return (
-    <MUIThemeProvider theme={theme}>
+    <MUIThemeProvider
+      theme={theme}
+      defaultMode={resolvedTheme as "light" | "dark"}
+    >
       <CssBaseline />
       {children}
     </MUIThemeProvider>

--- a/apps/next/src/components/theme-provider.tsx
+++ b/apps/next/src/components/theme-provider.tsx
@@ -7,36 +7,65 @@ import {
   StyledEngineProvider,
 } from "@mui/material/styles";
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v14-appRouter";
-import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes";
+import { useMemo } from "react";
 import resolveConfig from "tailwindcss/resolveConfig";
 import tailwindConfig from "../../tailwind.config";
 
 const twColors = resolveConfig(tailwindConfig).theme.colors;
 
-const theme = createTheme({
-  cssVariables: {
-    colorSchemeSelector: "class",
-  },
-  colorSchemes: {
-    light: {
-      palette: {
-        primary: {
-          main: twColors.sky["700"],
+function MuiThemeWrapper({ children }: { children: React.ReactNode }) {
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
+
+  const theme = useMemo(
+    () =>
+      createTheme({
+        cssVariables: {
+          colorSchemeSelector: "class",
         },
-      },
-    },
-    dark: {
-      palette: {
-        primary: {
-          main: twColors.sky["800"],
+        palette: {
+          mode: isDark ? "dark" : "light",
         },
-      },
-    },
-  },
-  typography: {
-    fontFamily: "var(--font-poppins), sans-serif",
-  },
-});
+        colorSchemes: {
+          light: {
+            palette: {
+              primary: {
+                main: twColors.sky["700"],
+              },
+            },
+          },
+          dark: {
+            palette: {
+              primary: {
+                main: twColors.blue["300"],
+              },
+              background: {
+                default: twColors.zinc["800"],
+                paper: twColors.zinc["700"],
+              },
+              text: {
+                primary: twColors.zinc["50"],
+                secondary: twColors.zinc["50"], //twColors.zinc["400"],
+              },
+              divider: twColors.zinc["700"],
+            },
+          },
+        },
+        typography: {
+          fontFamily: "var(--font-poppins), sans-serif",
+        },
+      }),
+    [isDark],
+  );
+
+  return (
+    <MUIThemeProvider theme={theme}>
+      <CssBaseline />
+      {children}
+    </MUIThemeProvider>
+  );
+}
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   return (
@@ -47,10 +76,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
           defaultTheme="system"
           enableSystem
         >
-          <MUIThemeProvider theme={theme}>
-            <CssBaseline />
-            {children}
-          </MUIThemeProvider>
+          <MuiThemeWrapper>{children}</MuiThemeWrapper>
         </NextThemesProvider>
       </AppRouterCacheProvider>
     </StyledEngineProvider>

--- a/apps/next/src/components/theme-provider.tsx
+++ b/apps/next/src/components/theme-provider.tsx
@@ -7,42 +7,29 @@ import {
   StyledEngineProvider,
 } from "@mui/material/styles";
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v14-appRouter";
-import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes";
-import { useMemo } from "react";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
 import resolveConfig from "tailwindcss/resolveConfig";
 import tailwindConfig from "../../tailwind.config";
 
 const twColors = resolveConfig(tailwindConfig).theme.colors;
 
-function MuiThemeWrapper({ children }: { children: React.ReactNode }) {
-  const { resolvedTheme } = useTheme();
-  const isDark = resolvedTheme === "dark";
-
-  const theme = useMemo(
-    () =>
-      createTheme({
-        palette: {
-          mode: isDark ? "dark" : "light",
-          primary: {
-            main: isDark ? twColors.sky["800"] : twColors.sky["700"],
-          },
-        },  
+const theme = createTheme({
+  cssVariables: {
+    colorSchemeSelector: "class",
+  },
+  colorSchemes: {
+    light: {
+      palette: {
+        primary: {
+          main: twColors.sky["700"],
+        },
       },
     },
     dark: {
       palette: {
         primary: {
-          main: twColors.blue["300"],
+          main: twColors.sky["800"],
         },
-        background: {
-          default: twColors.zinc["800"],
-          paper: twColors.zinc["700"],
-        },
-        text: {
-          primary: twColors.zinc["50"],
-          secondary: twColors.zinc["50"], //twColors.zinc["400"],
-        },
-        divider: twColors.zinc["700"],
       },
     },
   },
@@ -60,7 +47,10 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
           defaultTheme="system"
           enableSystem
         >
-          <MuiThemeWrapper>{children}</MuiThemeWrapper>
+          <MUIThemeProvider theme={theme}>
+            <CssBaseline />
+            {children}
+          </MUIThemeProvider>
         </NextThemesProvider>
       </AppRouterCacheProvider>
     </StyledEngineProvider>

--- a/apps/next/src/components/theme-provider.tsx
+++ b/apps/next/src/components/theme-provider.tsx
@@ -26,8 +26,8 @@ function MuiThemeWrapper({ children }: { children: React.ReactNode }) {
           primary: {
             main: isDark ? twColors.sky["800"] : twColors.sky["700"],
           },
-        },
-nly when the problem's "induced width" is small, as it often creates large, complex functions.      },
+        },  
+      },
     },
     dark: {
       palette: {

--- a/apps/next/src/components/ui/sidebar/sidebar-content.tsx
+++ b/apps/next/src/components/ui/sidebar/sidebar-content.tsx
@@ -50,7 +50,11 @@ export default function SidebarContent({
   if (!mounted) return null;
 
   const handleSignOut = async () => {
+    const savedTheme = localStorage.getItem("theme");
     await signOut();
+    if (savedTheme) {
+      localStorage.setItem("theme", savedTheme);
+    }
     window.location.href = "/";
   };
 

--- a/apps/next/src/components/ui/sidebar/theme-toggle.tsx
+++ b/apps/next/src/components/ui/sidebar/theme-toggle.tsx
@@ -3,7 +3,7 @@
 /** biome-ignore-all lint/a11y/useFocusableInteractive: Will fix when using MUI. */
 "use client";
 
-import { DarkMode, LightMode } from "@mui/icons-material";
+import { DarkMode, DesktopWindows, LightMode } from "@mui/icons-material";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 import { Switch } from "@/components/ui/switch";
@@ -15,8 +15,16 @@ export function ThemeToggle() {
   useEffect(() => setMounted(true), []);
   if (!mounted) return null;
 
-  const isDark = (theme === "system" ? resolvedTheme : theme) === "dark";
-  const toggleTheme = () => setTheme(isDark ? "light" : "dark");
+  const isSystem = theme === "system";
+  const isDark = !isSystem && theme === "dark";
+
+  const toggleTheme = () => {
+    if (isSystem) {
+      setTheme(resolvedTheme === "dark" ? "light" : "dark");
+    } else {
+      setTheme(isDark ? "light" : "dark");
+    }
+  };
 
   return (
     <div
@@ -25,13 +33,15 @@ export function ThemeToggle() {
       className="flex w-full items-center justify-between px-3 py-2 rounded-md transition-colors cursor-pointer select-none hover:bg-accent hover:text-accent-foreground group"
     >
       <div className="flex gap-3 items-center">
-        {isDark ? (
+        {isSystem ? (
+          <DesktopWindows className="stroke-1 size-5" />
+        ) : isDark ? (
           <LightMode className="stroke-1 size-5" />
         ) : (
           <DarkMode className="stroke-1 size-5" />
         )}
         <span className="text-md font-medium">
-          {isDark ? "Light mode" : "Dark mode"}
+          {isSystem ? "Device" : isDark ? "Light mode" : "Dark mode"}
         </span>
       </div>
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                                                                                            
Fixes two theme toggle bugs: the toggle incorrectly collapsed the "system" (Device) theme into light/dark on fresh load, and the selected theme did not persist visually after sign-out and sign-in. The root cause of the persistence bug was MUI's colorSchemes feature independently managing the dark class on <html>, conflicting with next-themes and re-adding dark even when the stored preference was light.

## Changes
- [ ] handle theme === "system" as a distinct state; show "Device" label and DesktopWindows icon instead of collapsing to light/dark via resolvedTheme
- [ ] preserve localStorage["theme"] around signOut() as a safety measure in case auth clears storage
- [ ] replace MUI cssVariables/colorSchemes with a MuiThemeWrapper that reads resolvedTheme from next-themes and passes it to MUI as a standard palette.mode

### Testing Instructions
  1. Load the page fresh without a stored theme preference. The sidebar toggle should show Device by default
  2. Set theme to Light, sign out, sign back in. The app should remain in light mode after returning

Closes #664 
