### PR TITLE
fix(mobile): 🐛 pressing dining button while on page will switch dinin…

### DIFF
--- a/apps/next/src/components/ui/toolbar.tsx
+++ b/apps/next/src/components/ui/toolbar.tsx
@@ -407,8 +407,17 @@ function MobileToolbar(): React.JSX.Element {
     setEditPreferencesSnackbarOpen(true);
   };
 
+  const diningHref =
+    pathname === "/brandywine"
+      ? "/anteatery"
+      : pathname === "/anteatery"
+        ? "/brandywine"
+        : "/brandywine";
+
   const isActive = (href: string) => {
     if (href === "/") return pathname === "/";
+    if (href === "/brandywine")
+      return pathname === "/brandywine" || pathname === "/anteatery";
     return pathname?.startsWith(href);
   };
 
@@ -489,12 +498,14 @@ function MobileToolbar(): React.JSX.Element {
             {MOBILE_TOOLBAR_ELEMENTS.map((element) => {
               if (!element.href) return null;
 
+              const isDining = element.title === "Dining";
+              const effectiveHref = isDining ? diningHref : element.href;
               const active = isActive(element.href);
 
               return (
                 <Link
                   key={element.title}
-                  href={element.href}
+                  href={effectiveHref}
                   className={`
                     flex flex-col items-center justify-center
                     w-[64px]


### PR DESCRIPTION
## Summary
The mobile navbar's Dining button previously always linked to Brandywine, with no way to reach the Anteatery. Now, tapping Dining while on a dining hall page switches to the other hall. If you're on Brandywine it takes you to Anteatery, and vice versa. If you're anywhere else, it defaults to Brandywine.

## Changes
 - [ ] Dining button in the mobile navbar now toggles between Brandywine and Anteatery based on the current page
 - [ ] Dining icon stays active/highlighted when on either dining hall page

### Testing Instructions
1. Open the site on a mobile viewport
2. Navigate to `/brandywine` — tap the Dining icon in the bottom nav and confirm it takes you to `/anteatery`
3. From `/anteatery`, tap Dining again and confirm it returns to `/brandywine`
4. From any other page (e.g. Home), tap Dining and confirm it defaults to `/brandywine`

Closes #677