### PR TITLE
fix: 🐛 resize anteatery button to fit within mobile screen

### DIFF
--- a/apps/next/src/app/my-foods/page.tsx
+++ b/apps/next/src/app/my-foods/page.tsx
@@ -240,7 +240,7 @@ export default function MyFoodsPage() {
                 type="button"
                 onClick={() => setLocationFilter(loc)}
                 className={cn(
-                  "rounded-lg px-2 py-1.5 h-8 text-sm font-medium transition whitespace-nowrap flex-1 min-w-0",
+                  "rounded-lg px-2 py-1.5 h-8 text-sm font-medium transition whitespace-nowrap flex-1 min-w-0 truncate",
                   locationFilter === loc
                     ? "bg-sky-700 text-white shadow-sm"
                     : "bg-white border border-sky-700 hover:bg-zinc-100",

--- a/apps/next/src/app/my-foods/page.tsx
+++ b/apps/next/src/app/my-foods/page.tsx
@@ -240,7 +240,7 @@ export default function MyFoodsPage() {
                 type="button"
                 onClick={() => setLocationFilter(loc)}
                 className={cn(
-                  "rounded-lg px-4 py-1.5 h-8 text-sm font-medium transition whitespace-nowrap",
+                  "rounded-lg px-2 py-1.5 h-8 text-sm font-medium transition whitespace-nowrap flex-1 min-w-0",
                   locationFilter === loc
                     ? "bg-sky-700 text-white shadow-sm"
                     : "bg-white border border-sky-700 hover:bg-zinc-100",


### PR DESCRIPTION
## Summary
Anteatery button is no longer cut off on My Foods page

## Changes
- Modified classname styling of the location label buttons

### Testing Instructions
Test on localhost

Closes #678 
