### PR TITLE
fix(routing): 🐛 add Anteatery and Brandywine routes to resolve 404

### DIFF
--- a/apps/next/src/app/anteatery/page.tsx
+++ b/apps/next/src/app/anteatery/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import Side from "@/components/ui/side";
+import { HallEnum } from "@/utils/types";
+
+export default function AnteateryPage() {
+  return (
+    <div className="h-screen overflow-y-auto">
+      <Side hall={HallEnum.ANTEATERY} />
+    </div>
+  );
+}

--- a/apps/next/src/app/brandywine/page.tsx
+++ b/apps/next/src/app/brandywine/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import Side from "@/components/ui/side";
+import { HallEnum } from "@/utils/types";
+
+export default function BrandywinePage() {
+  return (
+    <div className="h-screen overflow-y-auto">
+      <Side hall={HallEnum.BRANDYWINE} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
The toolbar navigation now properly links for Anteatery and Brandywine. It pointed to /anteatery and /brandywine routes, but the actual folders and page files were missing, which caused the 404 errors when clicking on the dining hall options, but now it is fixed with the proper folders and page files.

## Changes
- Created /apps/next/src/app/anteatery/ directory with page.tsx
- Created /apps/next/src/app/brandywine/ directory with page.tsx
- Each page properly renders the Side component and just shows that for its respective dining hall

## Testing Instructions
1. Run the dev server
2. Open the website
3. Click Dining Halls in the navbar
4. Choose either Anteatery or Brandywine (I prefer Brandy cause LOTR)
5. Look at how the page loads properly with no more 404 (yay)

Closes #690 
