### PR TITLE
Bug 669: Home Upcoming Event Cards Title

### DIFF
--- a/apps/next/src/components/ui/card/upcoming-event-card.tsx
+++ b/apps/next/src/components/ui/card/upcoming-event-card.tsx
@@ -65,7 +65,7 @@ export default function UpcomingEventCard({
       >
         <div className="mb-3 flex items-start gap-2 min-w-0">
           <h3
-            className={`${titleSize} line-clamp-2 min-w-0 flex-1 whitespace-normal break-normal font-bold leading-tight text-sky-700`}
+            className={`${titleSize} line-clamp-2 min-w-0 flex-1 whitespace-normal break-words font-bold leading-tight text-sky-700`}
           >
             {event.title}
           </h3>


### PR DESCRIPTION
## Summary
-Originally for upcoming events, if the title of the event on the first line was too long it would get cut off. Now, the words from the first line overflow into the second line. If the overall event name is too long, it still returns the "..." after, preserving the same logic. The main change is just on the first line. 
- 

## Changes
- changed from break-normal to break-words CSS prop 
Examples: (first is the original title "Taste of the Mediterranean" to replicate the specific bug reported. Second is just a random event name to show it correctly overflows.)

<img width="125" height="170" alt="Screenshot 2026-04-21 at 9 32 50 AM" src="https://github.com/user-attachments/assets/b3ae495c-fc9f-4385-af5b-dd5502b2e955" />
<img width="131" height="178" alt="Screenshot 2026-04-21 at 9 34 11 AM" src="https://github.com/user-attachments/assets/9faae5d4-4fac-4097-84e7-b30db9bebdc1" />

Closes #
Bug 669 