### PR TITLE
673/mobile events screen

### DIFF
--- a/apps/next/src/app/events/page.tsx
+++ b/apps/next/src/app/events/page.tsx
@@ -115,8 +115,12 @@ const Events = () => {
         >
           <div>
             <h1 className="text-4xl font-bold text-sky-700 dark:text-sky-400">
-              Events
+              Dining Hall Events
             </h1>
+            <p className="text-zinc-600 dark:text-zinc-400 mt-1 font-medium">
+              Join us for special events and celebrations hosted at your local
+              dining halls!
+            </p>
             <FormControl fullWidth className={locationFormControlClasses}>
               <Select
                 id="location-select"

--- a/apps/next/src/app/events/page.tsx
+++ b/apps/next/src/app/events/page.tsx
@@ -115,12 +115,8 @@ const Events = () => {
         >
           <div>
             <h1 className="text-4xl font-bold text-sky-700 dark:text-sky-400">
-              Dining Hall Events
+              Events
             </h1>
-            <p className="text-zinc-600 dark:text-zinc-400 mt-1 font-medium">
-              Join us for special events and celebrations hosted at your local
-              dining halls!
-            </p>
             <FormControl fullWidth className={locationFormControlClasses}>
               <Select
                 id="location-select"

--- a/apps/next/src/app/events/page.tsx
+++ b/apps/next/src/app/events/page.tsx
@@ -115,6 +115,7 @@ const Events = () => {
 
   return isDesktop ? (
     <DesktopEventsView
+      isDesktop={isDesktop}
       currentDate={currentDate}
       setCurrentDate={setCurrentDate}
       selectedDiningHall={selectedDiningHall}

--- a/apps/next/src/app/events/page.tsx
+++ b/apps/next/src/app/events/page.tsx
@@ -120,6 +120,7 @@ const Events = () => {
             <FormControl fullWidth className={locationFormControlClasses}>
               <Select
                 id="location-select"
+                size="small"
                 className={locationSelectClasses}
                 value={selectedDiningHall}
                 onChange={handleLocationChange}

--- a/apps/next/src/app/events/page.tsx
+++ b/apps/next/src/app/events/page.tsx
@@ -117,9 +117,7 @@ const Events = () => {
     <DesktopEventsView
       isDesktop={isDesktop}
       currentDate={currentDate}
-      setCurrentDate={setCurrentDate}
       selectedDiningHall={selectedDiningHall}
-      setSelectedDiningHall={setSelectedDiningHall}
       selectedEventType={selectedEventType}
       setSelectedEventType={setSelectedEventType}
       viewMode={viewMode}
@@ -141,17 +139,13 @@ const Events = () => {
       currentDate={currentDate}
       setCurrentDate={setCurrentDate}
       selectedDiningHall={selectedDiningHall}
-      setSelectedDiningHall={setSelectedDiningHall}
       filteredEvents={filteredEvents}
       selectedEventData={selectedEventData}
       isLoading={isLoading}
       error={error}
       handleLocationChange={handleLocationChange}
-      viewMode={viewMode}
-      setViewMode={setViewMode}
       handleSelectEvent={handleSelectEvent}
       handleClose={handleClose}
-      now={now}
     />
   );
 };

--- a/apps/next/src/app/events/page.tsx
+++ b/apps/next/src/app/events/page.tsx
@@ -6,6 +6,7 @@ import Button from "@mui/material/Button";
 import { useState } from "react";
 import { trpc } from "@/utils/trpc";
 import "react-big-calendar/lib/css/react-big-calendar.css";
+import { FormControl, MenuItem, Select } from "@mui/material";
 import { addMonths, endOfMonth, startOfMonth, subMonths } from "date-fns";
 import CalendarView from "@/components/ui/calendar-view";
 import EventCard, { type EventInfo } from "@/components/ui/card/event-card";
@@ -27,6 +28,10 @@ const Events = () => {
   );
   const [currentDate, setCurrentDate] = useState(new Date());
   const now = new Date();
+  const locationFormControlClasses =
+    "mt-1.5 w-40 sm:w-[180px] [&_.MuiOutlinedInput-root]:min-h-[38px] [&_.MuiOutlinedInput-root]:rounded-lg [&_.MuiOutlinedInput-root]:bg-white [&_.MuiOutlinedInput-root]:text-[0.9rem] [&_.MuiOutlinedInput-root]:text-slate-900 [&_.MuiOutlinedInput-notchedOutline]:border-sky-700 [&_.MuiOutlinedInput-root:hover_.MuiOutlinedInput-notchedOutline]:border-sky-800 [&_.MuiOutlinedInput-root.Mui-focused_.MuiOutlinedInput-notchedOutline]:border-2 [&_.MuiOutlinedInput-root.Mui-focused_.MuiOutlinedInput-notchedOutline]:border-sky-700";
+  const locationSelectClasses =
+    "[&_.MuiSelect-select]:!py-2 [&_.MuiSelect-select]:!pl-3 [&_.MuiSelect-select]:!pr-[30px] [&_.MuiSelect-icon]:right-2 [&_.MuiSelect-icon]:text-sky-700";
 
   const {
     data: events,
@@ -67,6 +72,10 @@ const Events = () => {
   }));
 
   const isDesktop = useMediaQuery("(min-width: 768px)");
+
+  const handleLocationChange = (event: any) => {
+    setSelectedDiningHall(event.target.value);
+  };
 
   const handleSelectEvent = (calendarEvent: any) => {
     const resource = calendarEvent.resource;
@@ -112,6 +121,19 @@ const Events = () => {
               Join us for special events and celebrations hosted at your local
               dining halls!
             </p>
+            <FormControl fullWidth className={locationFormControlClasses}>
+              <Select
+                id="location-select"
+                size="small"
+                className={locationSelectClasses}
+                value={selectedDiningHall}
+                onChange={handleLocationChange}
+              >
+                <MenuItem value="both">All Locations</MenuItem>
+                <MenuItem value={HallEnum.BRANDYWINE}>Brandywine</MenuItem>
+                <MenuItem value={HallEnum.ANTEATERY}>The Anteatery</MenuItem>
+              </Select>
+            </FormControl>
             <div className="flex gap-2 mt-3 items-center">
               <span className="text-sm font-medium text-slate-900">View:</span>
 

--- a/apps/next/src/app/events/page.tsx
+++ b/apps/next/src/app/events/page.tsx
@@ -6,7 +6,6 @@ import Button from "@mui/material/Button";
 import { useState } from "react";
 import { trpc } from "@/utils/trpc";
 import "react-big-calendar/lib/css/react-big-calendar.css";
-import { FormControl, MenuItem, Select } from "@mui/material";
 import { addMonths, endOfMonth, startOfMonth, subMonths } from "date-fns";
 import CalendarView from "@/components/ui/calendar-view";
 import EventCard, { type EventInfo } from "@/components/ui/card/event-card";
@@ -28,10 +27,6 @@ const Events = () => {
   );
   const [currentDate, setCurrentDate] = useState(new Date());
   const now = new Date();
-  const locationFormControlClasses =
-    "mt-1.5 w-40 sm:w-[180px] [&_.MuiOutlinedInput-root]:min-h-[38px] [&_.MuiOutlinedInput-root]:rounded-lg [&_.MuiOutlinedInput-root]:bg-white [&_.MuiOutlinedInput-root]:text-[0.9rem] [&_.MuiOutlinedInput-root]:text-slate-900 [&_.MuiOutlinedInput-notchedOutline]:border-sky-700 [&_.MuiOutlinedInput-root:hover_.MuiOutlinedInput-notchedOutline]:border-sky-800 [&_.MuiOutlinedInput-root.Mui-focused_.MuiOutlinedInput-notchedOutline]:border-2 [&_.MuiOutlinedInput-root.Mui-focused_.MuiOutlinedInput-notchedOutline]:border-sky-700";
-  const locationSelectClasses =
-    "[&_.MuiSelect-select]:!py-2 [&_.MuiSelect-select]:!pl-3 [&_.MuiSelect-select]:!pr-[30px] [&_.MuiSelect-icon]:right-2 [&_.MuiSelect-icon]:text-sky-700";
 
   const {
     data: events,
@@ -72,10 +67,6 @@ const Events = () => {
   }));
 
   const isDesktop = useMediaQuery("(min-width: 768px)");
-
-  const handleLocationChange = (event: any) => {
-    setSelectedDiningHall(event.target.value);
-  };
 
   const handleSelectEvent = (calendarEvent: any) => {
     const resource = calendarEvent.resource;
@@ -121,19 +112,6 @@ const Events = () => {
               Join us for special events and celebrations hosted at your local
               dining halls!
             </p>
-            <FormControl fullWidth className={locationFormControlClasses}>
-              <Select
-                id="location-select"
-                size="small"
-                className={locationSelectClasses}
-                value={selectedDiningHall}
-                onChange={handleLocationChange}
-              >
-                <MenuItem value="both">All Locations</MenuItem>
-                <MenuItem value={HallEnum.BRANDYWINE}>Brandywine</MenuItem>
-                <MenuItem value={HallEnum.ANTEATERY}>The Anteatery</MenuItem>
-              </Select>
-            </FormControl>
             <div className="flex gap-2 mt-3 items-center">
               <span className="text-sm font-medium text-slate-900">View:</span>
 

--- a/apps/next/src/app/events/page.tsx
+++ b/apps/next/src/app/events/page.tsx
@@ -2,7 +2,7 @@
 
 import type { SelectChangeEvent } from "@mui/material/Select";
 import { addMonths, endOfMonth, startOfMonth, subMonths } from "date-fns";
-import { useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { EventInfo } from "@/components/ui/card/event-card";
 import DesktopEventsView from "@/components/ui/desktop-events-view";
 import MobileEventsView from "@/components/ui/mobile-events-view";
@@ -39,6 +39,27 @@ const Events = () => {
     before: endOfMonth(currentDate),
   });
 
+  const { data: upcomingEvents } = trpc.event.upcoming.useQuery();
+
+  const availableMonths = useMemo(() => {
+    if (!upcomingEvents?.length) return [];
+    const seen = new Set<string>();
+    const months: { year: number; monthIndex: number }[] = [];
+    for (const event of upcomingEvents) {
+      if (!event.start) continue;
+      const date = new Date(event.start);
+      const year = date.getFullYear();
+      const monthIndex = date.getMonth();
+      const key = `${year}-${monthIndex}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      months.push({ year, monthIndex });
+    }
+    return months.sort(
+      (a, b) => a.year - b.year || a.monthIndex - b.monthIndex,
+    );
+  }, [upcomingEvents]);
+
   const sortedEvents =
     events?.length > 0
       ? [...events].sort(
@@ -46,18 +67,30 @@ const Events = () => {
         )
       : [];
 
-  const filteredEvents = sortedEvents.filter((event) => {
-    const matchesDiningHall =
-      selectedDiningHall === "both" ||
-      (selectedDiningHall === "anteatery" &&
-        event.restaurantId === "anteatery") ||
-      (selectedDiningHall === "brandywine" &&
-        event.restaurantId === "brandywine");
-    const matchesEventType =
-      selectedEventType === "both" ||
-      getEventType(event.title) === selectedEventType;
-    return matchesDiningHall && matchesEventType;
-  });
+  const matchesFilters = useCallback(
+    (event: { restaurantId: string; title: string }) => {
+      const matchesDiningHall =
+        selectedDiningHall === "both" ||
+        (selectedDiningHall === "anteatery" &&
+          event.restaurantId === "anteatery") ||
+        (selectedDiningHall === "brandywine" &&
+          event.restaurantId === "brandywine");
+      const matchesEventType =
+        selectedEventType === "both" ||
+        getEventType(event.title) === selectedEventType;
+      return matchesDiningHall && matchesEventType;
+    },
+    [selectedDiningHall, selectedEventType],
+  );
+
+  const filteredEvents = sortedEvents.filter(matchesFilters);
+
+  const filteredUpcomingEvents = useMemo(() => {
+    if (!upcomingEvents?.length) return [];
+    return [...upcomingEvents]
+      .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime())
+      .filter(matchesFilters);
+  }, [upcomingEvents, matchesFilters]);
 
   const calendarEvents = filteredEvents.map((event) => ({
     title: event.title,
@@ -140,12 +173,14 @@ const Events = () => {
       setCurrentDate={setCurrentDate}
       selectedDiningHall={selectedDiningHall}
       filteredEvents={filteredEvents}
+      filteredUpcomingEvents={filteredUpcomingEvents}
       selectedEventData={selectedEventData}
       isLoading={isLoading}
       error={error}
       handleLocationChange={handleLocationChange}
       handleSelectEvent={handleSelectEvent}
       handleClose={handleClose}
+      availableMonths={availableMonths}
     />
   );
 };

--- a/apps/next/src/app/events/page.tsx
+++ b/apps/next/src/app/events/page.tsx
@@ -120,7 +120,6 @@ const Events = () => {
             <FormControl fullWidth className={locationFormControlClasses}>
               <Select
                 id="location-select"
-                size="small"
                 className={locationSelectClasses}
                 value={selectedDiningHall}
                 onChange={handleLocationChange}

--- a/apps/next/src/app/events/page.tsx
+++ b/apps/next/src/app/events/page.tsx
@@ -1,17 +1,14 @@
 "use client";
 
-import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
-import GridOnIcon from "@mui/icons-material/GridOn";
-import Button from "@mui/material/Button";
-import { useState } from "react";
-import { trpc } from "@/utils/trpc";
-import "react-big-calendar/lib/css/react-big-calendar.css";
+import type { SelectChangeEvent } from "@mui/material/Select";
 import { addMonths, endOfMonth, startOfMonth, subMonths } from "date-fns";
-import CalendarView from "@/components/ui/calendar-view";
-import EventCard, { type EventInfo } from "@/components/ui/card/event-card";
-import EventCardSkeleton from "@/components/ui/skeleton/event-card-skeleton";
+import { useState } from "react";
+import type { EventInfo } from "@/components/ui/card/event-card";
+import DesktopEventsView from "@/components/ui/desktop-events-view";
+import MobileEventsView from "@/components/ui/mobile-events-view";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { getEventType } from "@/utils/funcs";
+import { trpc } from "@/utils/trpc";
 import { HallEnum } from "@/utils/types";
 
 const Events = () => {
@@ -28,6 +25,11 @@ const Events = () => {
   const [currentDate, setCurrentDate] = useState(new Date());
   const now = new Date();
 
+  const _locationFormControlClasses =
+    "mt-1.5 w-40 sm:w-[180px] [&_.MuiOutlinedInput-root]:min-h-[38px] [&_.MuiOutlinedInput-root]:rounded-lg [&_.MuiOutlinedInput-root]:bg-white [&_.MuiOutlinedInput-root]:text-[0.9rem] [&_.MuiOutlinedInput-root]:text-slate-900 [&_.MuiOutlinedInput-notchedOutline]:border-sky-700 [&_.MuiOutlinedInput-root:hover_.MuiOutlinedInput-notchedOutline]:border-sky-800 [&_.MuiOutlinedInput-root.Mui-focused_.MuiOutlinedInput-notchedOutline]:border-2 [&_.MuiOutlinedInput-root.Mui-focused_.MuiOutlinedInput-notchedOutline]:border-sky-700";
+  const _locationSelectClasses =
+    "[&_.MuiSelect-select]:!py-2 [&_.MuiSelect-select]:!pl-3 [&_.MuiSelect-select]:!pr-[30px] [&_.MuiSelect-icon]:right-2 [&_.MuiSelect-icon]:text-sky-700";
+
   const {
     data: events,
     isLoading,
@@ -40,12 +42,11 @@ const Events = () => {
   const sortedEvents =
     events?.length > 0
       ? [...events].sort(
-          (a: any, b: any) =>
-            new Date(a.start).getTime() - new Date(b.start).getTime(),
+          (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
         )
       : [];
 
-  const filteredEvents = sortedEvents.filter((event: any) => {
+  const filteredEvents = sortedEvents.filter((event) => {
     const matchesDiningHall =
       selectedDiningHall === "both" ||
       (selectedDiningHall === "anteatery" &&
@@ -58,7 +59,7 @@ const Events = () => {
     return matchesDiningHall && matchesEventType;
   });
 
-  const calendarEvents = filteredEvents.map((event: any) => ({
+  const calendarEvents = filteredEvents.map((event) => ({
     title: event.title,
     start: new Date(event.start),
     end: new Date(event.end),
@@ -68,21 +69,33 @@ const Events = () => {
 
   const isDesktop = useMediaQuery("(min-width: 768px)");
 
-  const handleSelectEvent = (calendarEvent: any) => {
+  const handleLocationChange = (
+    event: SelectChangeEvent<"both" | "anteatery" | "brandywine">,
+  ) => {
+    setSelectedDiningHall(
+      event.target.value as "both" | "anteatery" | "brandywine",
+    );
+  };
+
+  const handleSelectEvent = (calendarEvent: {
+    resource: Record<string, unknown>;
+  }) => {
     const resource = calendarEvent.resource;
     setSelectedEventData({
-      name: resource.title,
-      shortDesc: resource.shortDescription,
-      longDesc: resource.longDescription,
-      imgSrc: resource.image,
-      alt: resource.title + " promotion image",
-      startTime: resource.start,
-      endTime: resource.end,
+      name: (resource.title as string) || "",
+      shortDesc: (resource.shortDescription as string) || "",
+      longDesc: (resource.longDescription as string) || "",
+      imgSrc: (resource.image as string) || "",
+      alt: `${(resource.title as string) || ""} promotion image`,
+      startTime: resource.start as Date,
+      endTime: resource.end as Date,
       location:
-        resource.restaurantId === "anteatery"
+        (resource.restaurantId as string) === "anteatery"
           ? HallEnum.ANTEATERY
           : HallEnum.BRANDYWINE,
-      isOngoing: resource.start <= now && resource.end >= now,
+      isOngoing:
+        (resource.start as Date) <= now && (resource.end as Date) >= now,
+      type: getEventType((resource.title as string) || ""),
     });
   };
 
@@ -96,215 +109,49 @@ const Events = () => {
     setCurrentDate(subMonths(currentDate, 1));
   };
 
-  return (
-    <div className="max-w-full h-screen ">
-      <div className="fixed top-0 left-0 w-full h-16 bg-sky-700/30 dark:bg-sky-900/40 z-0" />
-      <div className="z-0 flex flex-col h-full overflow-x-hidden">
-        <div
-          className="flex flex-col gap-4 justify-center w-full p-5 pt-16 sm:px-12 sm:py-8 sm:pt-20"
-          id="event-scroll"
-        >
-          <div>
-            <h1 className="text-4xl font-bold text-sky-700 dark:text-sky-400">
-              Dining Hall Events
-            </h1>
-            <p className="text-zinc-600 dark:text-zinc-400 mt-1 font-medium">
-              Join us for special events and celebrations hosted at your local
-              dining halls!
-            </p>
-            <div className="flex gap-2 mt-3 items-center">
-              <span className="text-sm font-medium text-slate-900">View:</span>
+  if (isDesktop === null) {
+    return null; // Return null on initial render until media query state is determined
+  }
 
-              {/* Grid View Button */}
-              <Button
-                onClick={() => setViewMode("grid")}
-                variant="outlined"
-                size="small"
-                className={`!px-4 !py-1 flex items-center justify-center !normal-case ${
-                  viewMode === "grid"
-                    ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500"
-                    : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700"
-                }`}
-              >
-                <GridOnIcon className="mr-1" sx={{ fontSize: 18 }} />
-                Grid View
-              </Button>
-
-              {/* Calendar View Button */}
-              <Button
-                onClick={() => setViewMode("calendar")}
-                variant="outlined"
-                size="small"
-                className={`!px-4 !py-1 flex items-center justify-center !normal-case ${
-                  viewMode === "calendar"
-                    ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500"
-                    : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700"
-                }`}
-              >
-                <CalendarTodayIcon className="mr-1" sx={{ fontSize: 18 }} />
-                Calendar View
-              </Button>
-            </div>
-
-            {/* Filter Bar */}
-            <div className="flex flex-wrap gap-8 w-full bg-sky-100 dark:bg-zinc-900/50 border dark:border-zinc-800 rounded-lg p-5 pb-8 mt-4">
-              <div className="flex flex-col gap-3">
-                <span className="text-sm font-medium text-slate-900 dark:text-zinc-200">
-                  Event Type
-                </span>
-                <div className="flex gap-3">
-                  <Button
-                    variant="outlined"
-                    size="small"
-                    onClick={() => setSelectedEventType("both")}
-                    className={`!px-4 !py-1 flex items-center justify-center !normal-case !text-sm !font-thin ${
-                      selectedEventType === "both"
-                        ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500"
-                        : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700"
-                    }`}
-                  >
-                    All Events
-                  </Button>
-                  <Button
-                    variant="outlined"
-                    size="small"
-                    onClick={() => setSelectedEventType("special")}
-                    className={`!px-4 !py-1 flex items-center justify-center !normal-case !text-sm !font-thin ${
-                      selectedEventType === "special"
-                        ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500 hover:!text-white"
-                        : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700 hover:!text-slate-900"
-                    }`}
-                  >
-                    Special Meals
-                  </Button>
-                  <Button
-                    variant="outlined"
-                    size="small"
-                    onClick={() => setSelectedEventType("celebration")}
-                    className={`!px-4 !py-1 flex items-center justify-center !normal-case !text-sm !font-thin ${
-                      selectedEventType === "celebration"
-                        ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500 hover:!text-white"
-                        : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700 hover:!text-slate-900"
-                    }`}
-                  >
-                    Celebration
-                  </Button>
-                </div>
-              </div>
-              <div className="flex flex-col gap-3">
-                <span className="text-sm font-medium text-slate-900">
-                  Location
-                </span>
-                <div className="flex gap-3">
-                  <Button
-                    variant="outlined"
-                    size="small"
-                    onClick={() => setSelectedDiningHall("both")}
-                    className={`!px-4 !py-1 flex items-center justify-center !normal-case !text-sm !font-thin ${
-                      selectedDiningHall === "both"
-                        ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500 hover:!text-white"
-                        : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700 hover:!text-slate-900"
-                    }`}
-                  >
-                    All Locations
-                  </Button>
-                  <Button
-                    variant="outlined"
-                    size="small"
-                    onClick={() => setSelectedDiningHall("brandywine")}
-                    className={`!px-4 !py-1 flex items-center justify-center !normal-case !text-sm !font-thin ${
-                      selectedDiningHall === "brandywine"
-                        ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500 hover:!text-white"
-                        : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700 hover:!text-slate-900"
-                    }`}
-                  >
-                    Brandywine
-                  </Button>
-                  <Button
-                    variant="outlined"
-                    size="small"
-                    onClick={() => setSelectedDiningHall("anteatery")}
-                    className={`!px-4 !py-1 flex items-center justify-center !normal-case !text-sm !font-thin ${
-                      selectedDiningHall === "anteatery"
-                        ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500 hover:!text-white"
-                        : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700 hover:!text-slate-900"
-                    }`}
-                  >
-                    Anteatery
-                  </Button>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Show skeletons while loading */}
-          {isLoading && (
-            <>
-              <EventCardSkeleton />
-              <EventCardSkeleton />
-              <EventCardSkeleton />
-            </>
-          )}
-          {error && (
-            <p className="text-red-500 w-full text-center">
-              Error loading data: {error.message}
-            </p>
-          )}
-          {/* GRID DISPLAY: Map over the fetched events once loaded */}
-          {!isLoading && !error && viewMode === "grid" && (
-            <>
-              <p className="text-sm text-zinc-700 dark:text-zinc-400">
-                Showing {filteredEvents.length} event
-                {filteredEvents.length !== 1 ? "s" : ""}
-              </p>
-
-              <div className="flex sm:grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-12 overflow-x-auto sm:overflow-visible pb-2 sm:pb-0">
-                {filteredEvents.map((event: any): any => (
-                  <EventCard
-                    key={`${event.title}-${event.start}-${event.restaurantId}`}
-                    name={event.title}
-                    imgSrc={event.image}
-                    alt={`${event.title} promotion image.`}
-                    startTime={event.start}
-                    endTime={event.end}
-                    location={
-                      event.restaurantId === "anteatery"
-                        ? HallEnum.ANTEATERY
-                        : HallEnum.BRANDYWINE
-                    }
-                    shortDesc={event.shortDescription}
-                    longDesc={event.longDescription}
-                    isOngoing={event.start <= now && event.end >= now}
-                  />
-                ))}
-              </div>
-              {filteredEvents.length === 0 && (
-                <p className="text-center text-zinc-700 py-5">
-                  No events found :(
-                </p>
-              )}
-            </>
-          )}
-
-          {/* CALENDAR DISPLAY */}
-          {!isLoading && !error && viewMode === "calendar" && (
-            <CalendarView
-              isDesktop={isDesktop}
-              viewMode={viewMode}
-              isLoading={isLoading}
-              error={error}
-              currentDate={currentDate}
-              calendarEvents={calendarEvents}
-              selectedEventData={selectedEventData}
-              onPreviousMonth={viewPreviousMonthsEvents}
-              onNextMonth={viewNextMonthsEvents}
-              onSelectEvent={handleSelectEvent}
-              onCloseDetails={handleClose}
-            />
-          )}
-        </div>
-      </div>
-    </div>
+  return isDesktop ? (
+    <DesktopEventsView
+      currentDate={currentDate}
+      setCurrentDate={setCurrentDate}
+      selectedDiningHall={selectedDiningHall}
+      setSelectedDiningHall={setSelectedDiningHall}
+      selectedEventType={selectedEventType}
+      setSelectedEventType={setSelectedEventType}
+      viewMode={viewMode}
+      setViewMode={setViewMode}
+      filteredEvents={filteredEvents}
+      calendarEvents={calendarEvents}
+      isLoading={isLoading}
+      error={error}
+      selectedEventData={selectedEventData}
+      handleSelectEvent={handleSelectEvent}
+      handleClose={handleClose}
+      now={now}
+      handleLocationChange={handleLocationChange}
+      viewNextMonthsEvents={viewNextMonthsEvents}
+      viewPreviousMonthsEvents={viewPreviousMonthsEvents}
+    />
+  ) : (
+    <MobileEventsView
+      currentDate={currentDate}
+      setCurrentDate={setCurrentDate}
+      selectedDiningHall={selectedDiningHall}
+      setSelectedDiningHall={setSelectedDiningHall}
+      filteredEvents={filteredEvents}
+      selectedEventData={selectedEventData}
+      isLoading={isLoading}
+      error={error}
+      handleLocationChange={handleLocationChange}
+      viewMode={viewMode}
+      setViewMode={setViewMode}
+      handleSelectEvent={handleSelectEvent}
+      handleClose={handleClose}
+      now={now}
+    />
   );
 };
 

--- a/apps/next/src/components/ui/calendar-view.tsx
+++ b/apps/next/src/components/ui/calendar-view.tsx
@@ -111,15 +111,16 @@ const CalendarView = ({
         <Dialog
           open={Boolean(selectedEventData)}
           onClose={onCloseDetails}
-          maxWidth={false}
-          slotProps={{
-            paper: {
-              sx: {
-                width: "570px",
-                maxWidth: "90vw",
-                borderRadius: "6px",
-                overflow: "hidden",
-              },
+          maxWidth="sm"
+          PaperProps={{
+            sx: {
+              bgcolor: "background.paper",
+              width: "570px",
+              maxWidth: "90vw",
+              margin: 2,
+              padding: 0,
+              borderRadius: "6px",
+              overflow: "hidden",
             },
           }}
         >

--- a/apps/next/src/components/ui/card/event-card.tsx
+++ b/apps/next/src/components/ui/card/event-card.tsx
@@ -143,18 +143,16 @@ export default function EventCard(props: EventInfo): React.JSX.Element {
         <Dialog
           open={open}
           onClose={handleClose}
-          maxWidth={false}
-          slotProps={{
-            paper: {
-              sx: {
-                bgcolor: "background.paper",
-                width: "570px",
-                maxWidth: "90vw",
-                margin: 2,
-                padding: 0,
-                overflow: "hidden",
-                borderRadius: "6px",
-              },
+          maxWidth="sm"
+          PaperProps={{
+            sx: {
+              bgcolor: "background.paper",
+              width: "570px",
+              maxWidth: "90vw",
+              margin: 2,
+              padding: 0,
+              overflow: "hidden",
+              borderRadius: "6px",
             },
           }}
         >

--- a/apps/next/src/components/ui/desktop-events-view.tsx
+++ b/apps/next/src/components/ui/desktop-events-view.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
+import GridOnIcon from "@mui/icons-material/GridOn";
+import Button from "@mui/material/Button";
+import type { SelectChangeEvent } from "@mui/material/Select";
+import CalendarView from "@/components/ui/calendar-view";
+import EventCard, { type EventInfo } from "@/components/ui/card/event-card";
+import EventCardSkeleton from "@/components/ui/skeleton/event-card-skeleton";
+import { HallEnum } from "@/utils/types";
+
+interface DesktopEventsViewProps {
+  isDesktop: boolean;
+  selectedDiningHall: "both" | "anteatery" | "brandywine";
+  handleLocationChange: (
+    event: SelectChangeEvent<"both" | "anteatery" | "brandywine">,
+  ) => void;
+  viewMode: "grid" | "calendar";
+  setViewMode: (mode: "grid" | "calendar") => void;
+  selectedEventType: "both" | "special" | "celebration";
+  setSelectedEventType: (type: "both" | "special" | "celebration") => void;
+  isLoading: boolean;
+  error: Error | null;
+  filteredEvents: EventInfo[];
+  calendarEvents: {
+    title: string;
+    start: Date;
+    end: Date;
+    resource: EventInfo;
+    allDay: boolean;
+  }[];
+  currentDate: Date;
+  selectedEventData: EventInfo | null;
+  handleSelectEvent: (calendarEvent: { resource: EventInfo }) => void;
+  handleClose: () => void;
+  viewPreviousMonthsEvents: () => void;
+  viewNextMonthsEvents: () => void;
+  now: Date;
+}
+
+const DesktopEventsView = ({
+  isDesktop,
+  selectedDiningHall,
+  handleLocationChange,
+  viewMode,
+  setViewMode,
+  selectedEventType,
+  setSelectedEventType,
+  isLoading,
+  error,
+  filteredEvents,
+  calendarEvents,
+  currentDate,
+  selectedEventData,
+  handleSelectEvent,
+  handleClose,
+  viewPreviousMonthsEvents,
+  viewNextMonthsEvents,
+  now,
+}: DesktopEventsViewProps) => {
+  const _locationFormControlClasses =
+    "mt-1.5 w-40 sm:w-[180px] [&_.MuiOutlinedInput-root]:min-h-[38px] [&_.MuiOutlinedInput-root]:rounded-lg [&_.MuiOutlinedInput-root]:bg-white [&_.MuiOutlinedInput-root]:text-[0.9rem] [&_.MuiOutlinedInput-root]:text-slate-900 [&_.MuiOutlinedInput-notchedOutline]:border-sky-700 [&_.MuiOutlinedInput-root:hover_.MuiOutlinedInput-notchedOutline]:border-sky-800 [&_.MuiOutlinedInput-root.Mui-focused_.MuiOutlinedInput-notchedOutline]:border-2 [&_.MuiOutlinedInput-root.Mui-focused_.MuiOutlinedInput-notchedOutline]:border-sky-700";
+  const _locationSelectClasses =
+    "[&_.MuiSelect-select]:!py-2 [&_.MuiSelect-select]:!pl-3 [&_.MuiSelect-select]:!pr-[30px] [&_.MuiSelect-icon]:right-2 [&_.MuiSelect-icon]:text-sky-700";
+
+  return (
+    <div className="max-w-full h-screen">
+      <div className="fixed top-0 left-0 w-full h-16 bg-sky-700/30 dark:bg-sky-900/40 z-0" />
+      <div className="z-0 flex flex-col h-full overflow-x-hidden">
+        <div
+          className="flex flex-col gap-4 justify-center w-full p-5 pt-16 sm:px-12 sm:py-8 sm:pt-20"
+          id="event-scroll"
+        >
+          <div>
+            <h1 className="text-4xl font-bold text-sky-700 dark:text-sky-400">
+              Dining Hall Events
+            </h1>
+            <p className="text-zinc-600 dark:text-zinc-400 mt-1 font-medium">
+              Join us for special events and celebrations hosted at your local
+              dining halls!
+            </p>
+            <div className="flex gap-2 mt-3 items-center">
+              <span className="text-sm font-medium text-slate-900">View:</span>
+
+              {/* Grid View Button */}
+              <Button
+                onClick={() => setViewMode("grid")}
+                variant="outlined"
+                size="small"
+                className={`!px-4 !py-1 flex items-center justify-center !normal-case ${
+                  viewMode === "grid"
+                    ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500"
+                    : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700"
+                }`}
+              >
+                <GridOnIcon className="mr-1" sx={{ fontSize: 18 }} />
+                Grid View
+              </Button>
+
+              {/* Calendar View Button */}
+              <Button
+                onClick={() => setViewMode("calendar")}
+                variant="outlined"
+                size="small"
+                className={`!px-4 !py-1 flex items-center justify-center !normal-case ${
+                  viewMode === "calendar"
+                    ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500"
+                    : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700"
+                }`}
+              >
+                <CalendarTodayIcon className="mr-1" sx={{ fontSize: 18 }} />
+                Calendar View
+              </Button>
+            </div>
+
+            {/* Filter Bar */}
+            <div className="flex flex-wrap gap-8 w-full bg-sky-100 dark:bg-zinc-900/50 border dark:border-zinc-800 rounded-lg p-5 pb-8 mt-4">
+              <div className="flex flex-col gap-3">
+                <span className="text-sm font-medium text-slate-900 dark:text-zinc-200">
+                  Event Type
+                </span>
+                <div className="flex gap-3">
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={() => setSelectedEventType("both")}
+                    className={`!px-4 !py-1 flex items-center justify-center !normal-case !text-sm !font-thin ${
+                      selectedEventType === "both"
+                        ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500"
+                        : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700"
+                    }`}
+                  >
+                    All Events
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={() => setSelectedEventType("special")}
+                    className={`!px-4 !py-1 flex items-center justify-center !normal-case !text-sm !font-thin ${
+                      selectedEventType === "special"
+                        ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500 hover:!text-white"
+                        : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700 hover:!text-slate-900"
+                    }`}
+                  >
+                    Special Meals
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={() => setSelectedEventType("celebration")}
+                    className={`!px-4 !py-1 flex items-center justify-center !normal-case !text-sm !font-thin ${
+                      selectedEventType === "celebration"
+                        ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500 hover:!text-white"
+                        : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700 hover:!text-slate-900"
+                    }`}
+                  >
+                    Celebration
+                  </Button>
+                </div>
+              </div>
+              <div className="flex flex-col gap-3">
+                <span className="text-sm font-medium text-slate-900">
+                  Location
+                </span>
+                <div className="flex gap-3">
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={() =>
+                      handleLocationChange({ target: { value: "both" } })
+                    }
+                    className={`!px-4 !py-1 flex items-center justify-center !normal-case !text-sm !font-thin ${
+                      selectedDiningHall === "both"
+                        ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500 hover:!text-white"
+                        : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700 hover:!text-slate-900"
+                    }`}
+                  >
+                    All Locations
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={() =>
+                      handleLocationChange({ target: { value: "brandywine" } })
+                    }
+                    className={`!px-4 !py-1 flex items-center justify-center !normal-case !text-sm !font-thin ${
+                      selectedDiningHall === "brandywine"
+                        ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500 hover:!text-white"
+                        : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700 hover:!text-slate-900"
+                    }`}
+                  >
+                    Brandywine
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={() =>
+                      handleLocationChange({ target: { value: "anteatery" } })
+                    }
+                    className={`!px-4 !py-1 flex items-center justify-center !normal-case !text-sm !font-thin ${
+                      selectedDiningHall === "anteatery"
+                        ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500 hover:!text-white"
+                        : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700 hover:!text-slate-900"
+                    }`}
+                  >
+                    Anteatery
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Show skeletons while loading */}
+          {isLoading && (
+            <>
+              <EventCardSkeleton />
+              <EventCardSkeleton />
+              <EventCardSkeleton />
+            </>
+          )}
+          {error && (
+            <p className="text-red-500 w-full text-center">
+              Error loading data: {error.message}
+            </p>
+          )}
+          {/* GRID DISPLAY: Map over the fetched events once loaded */}
+          {!isLoading && !error && viewMode === "grid" && (
+            <>
+              <p className="text-sm text-zinc-700 dark:text-zinc-400">
+                Showing {filteredEvents.length} event
+                {filteredEvents.length !== 1 ? "s" : ""}
+              </p>
+
+              <div className="flex sm:grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-12 overflow-x-auto sm:overflow-visible pb-2 sm:pb-0">
+                {filteredEvents.map((event) => (
+                  <EventCard
+                    key={`${event.title}-${String(event.start)}-${event.restaurantId || event.location}`}
+                    name={event.title}
+                    imgSrc={event.image || event.imgSrc}
+                    alt={`${event.title} promotion image.`}
+                    startTime={event.start || event.startTime}
+                    endTime={event.end || event.endTime}
+                    location={
+                      event.restaurantId === "anteatery" ||
+                      event.location === HallEnum.ANTEATERY
+                        ? HallEnum.ANTEATERY
+                        : HallEnum.BRANDYWINE
+                    }
+                    shortDesc={event.shortDescription}
+                    longDesc={event.longDescription}
+                    isOngoing={event.start <= now && event.end >= now}
+                  />
+                ))}
+              </div>
+              {filteredEvents.length === 0 && (
+                <p className="text-center text-zinc-700 py-5">
+                  No events found :(
+                </p>
+              )}
+            </>
+          )}
+
+          {/* CALENDAR DISPLAY */}
+          {!isLoading && !error && viewMode === "calendar" && (
+            <CalendarView
+              isDesktop={isDesktop}
+              viewMode={viewMode}
+              isLoading={isLoading}
+              error={error}
+              currentDate={currentDate}
+              calendarEvents={calendarEvents}
+              selectedEventData={selectedEventData}
+              onPreviousMonth={viewPreviousMonthsEvents}
+              onNextMonth={viewNextMonthsEvents}
+              onSelectEvent={handleSelectEvent}
+              onCloseDetails={handleClose}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DesktopEventsView;

--- a/apps/next/src/components/ui/desktop-events-view.tsx
+++ b/apps/next/src/components/ui/desktop-events-view.tsx
@@ -31,7 +31,9 @@ interface DesktopEventsViewProps {
   }[];
   currentDate: Date;
   selectedEventData: EventInfo | null;
-  handleSelectEvent: (calendarEvent: { resource: EventInfo }) => void;
+  handleSelectEvent: (calendarEvent: {
+    resource: Record<string, unknown>;
+  }) => void;
   handleClose: () => void;
   viewPreviousMonthsEvents: () => void;
   viewNextMonthsEvents: () => void;

--- a/apps/next/src/components/ui/event-details-drawer.tsx
+++ b/apps/next/src/components/ui/event-details-drawer.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import CloseIcon from "@mui/icons-material/Close";
+import Drawer from "@mui/material/Drawer";
+import type { EventInfo } from "./card/event-card";
+import EventDrawerContent from "./event-drawer-content";
+
+interface EventDetailsDrawerProps {
+  selectedEventData: EventInfo | null;
+  selectedDayEvents: EventInfo[];
+  onClose: () => void;
+}
+
+const EventDetailsDrawer = ({
+  selectedEventData,
+  selectedDayEvents,
+  onClose,
+}: EventDetailsDrawerProps) => {
+  const open = Boolean(selectedEventData) || selectedDayEvents.length > 0;
+
+  return (
+    <Drawer
+      anchor="bottom"
+      open={open}
+      onClose={onClose}
+      sx={{
+        "& .MuiDrawer-paper": {
+          borderTopLeftRadius: "10px",
+          borderTopRightRadius: "10px",
+          height: "auto",
+          maxHeight: "90vh",
+          backgroundColor: selectedDayEvents.length === 1 ? "white" : "#f8fafc",
+        },
+      }}
+      className="dark:[&_.MuiDrawer-paper]:!bg-zinc-950"
+    >
+      <div className="relative w-full h-full flex flex-col overflow-y-auto">
+        {open && (
+          <button
+            type="button"
+            className="absolute top-3 right-4 z-50 bg-white/80 dark:bg-zinc-900/80 backdrop-blur rounded-full p-1 shadow hover:bg-white dark:hover:bg-zinc-800 transition-colors"
+            onClick={onClose}
+          >
+            <CloseIcon
+              className="text-zinc-600 dark:text-zinc-300"
+              fontSize="small"
+            />
+          </button>
+        )}
+
+        {selectedEventData ? (
+          <EventDrawerContent {...selectedEventData} />
+        ) : selectedDayEvents.length === 1 ? (
+          <EventDrawerContent {...selectedDayEvents[0]} />
+        ) : (
+          <div className="flex flex-col gap-4 p-4 pt-12 pb-10">
+            {selectedDayEvents.map((event, idx) => (
+              <div
+                key={`event-drawer-${event.name}-${idx}`}
+                className="bg-white dark:bg-zinc-900 rounded-xl overflow-hidden shadow-sm border border-slate-200 dark:border-zinc-800"
+              >
+                <EventDrawerContent {...event} />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </Drawer>
+  );
+};
+
+export default EventDetailsDrawer;

--- a/apps/next/src/components/ui/mobile-calendar-view.tsx
+++ b/apps/next/src/components/ui/mobile-calendar-view.tsx
@@ -149,7 +149,7 @@ const MobileCalendarView = ({
                 <div className="absolute -bottom-3 flex space-x-0.5">
                   {eventsOnDay.slice(0, 3).map((event) => (
                     <div
-                      key={event.title}
+                      key={`${event.title}-${String(event.start)}-${event.restaurantId || event.location}`}
                       className="w-1.5 h-1.5 rounded-full bg-sky-700 dark:bg-sky-400"
                     />
                   ))}

--- a/apps/next/src/components/ui/mobile-calendar-view.tsx
+++ b/apps/next/src/components/ui/mobile-calendar-view.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
+import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
+import {
+  addDays,
+  addMonths,
+  format,
+  isSameDay,
+  isSameMonth,
+  startOfMonth,
+  startOfWeek,
+  subMonths,
+} from "date-fns";
+import { useState } from "react";
+import type { EventInfo } from "./card/event-card";
+
+interface MobileCalendarViewProps {
+  currentDate: Date;
+  onDateChange: (date: Date) => void;
+  filteredEvents: EventInfo[];
+  onSelectEventDay: (date: Date, events: EventInfo[]) => void;
+  onOpenMonthPicker: () => void;
+}
+
+const MobileCalendarView = ({
+  currentDate,
+  onDateChange,
+  filteredEvents,
+  onSelectEventDay,
+  onOpenMonthPicker,
+}: MobileCalendarViewProps) => {
+  const [touchStart, setTouchStart] = useState<number | null>(null);
+  const [touchEnd, setTouchEnd] = useState<number | null>(null);
+
+  // Minimum swipe distance (in px)
+  const minSwipeDistance = 50;
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    setTouchEnd(null);
+    setTouchStart(e.targetTouches[0].clientX);
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    setTouchEnd(e.targetTouches[0].clientX);
+  };
+
+  const handleTouchEnd = () => {
+    if (!touchStart || !touchEnd) return;
+    const distance = touchStart - touchEnd;
+    const isLeftSwipe = distance > minSwipeDistance;
+    const isRightSwipe = distance < -minSwipeDistance;
+
+    if (isLeftSwipe) {
+      onDateChange(addMonths(currentDate, 1));
+    }
+    if (isRightSwipe) {
+      onDateChange(subMonths(currentDate, 1));
+    }
+  };
+
+  const monthStart = startOfMonth(currentDate);
+  const startDate = startOfWeek(monthStart);
+
+  const daysList = Array.from({ length: 42 }).map((_, index) =>
+    addDays(startDate, index),
+  );
+
+  const weekDays = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+  ];
+
+  const getEventsForDay = (date: Date) => {
+    return filteredEvents.filter((event) => {
+      return isSameDay(new Date(event.start), date);
+    });
+  };
+
+  return (
+    <div
+      className="flex flex-col flex-1 px-4 mt-4"
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+    >
+      <div className="flex items-center justify-between mb-6 px-2 w-full max-w-sm mx-auto">
+        <ArrowBackIosIcon
+          className="cursor-pointer text-slate-800 dark:text-zinc-200"
+          fontSize="small"
+          onClick={() => onDateChange(subMonths(currentDate, 1))}
+        />
+        <button
+          type="button"
+          className="text-2xl font-bold text-sky-700 dark:text-sky-400 focus:outline-none"
+          onClick={onOpenMonthPicker}
+        >
+          {format(currentDate, "MMMM yyyy")} <span className="text-sm">▼</span>
+        </button>
+        <ArrowForwardIosIcon
+          className="cursor-pointer text-slate-800 dark:text-zinc-200"
+          fontSize="small"
+          onClick={() => onDateChange(addMonths(currentDate, 1))}
+        />
+      </div>
+
+      <div className="grid grid-cols-7 gap-y-6 gap-x-2 text-center w-full max-w-sm mx-auto pb-10">
+        {weekDays.map((day) => (
+          <div
+            key={`header-${day}`}
+            className="text-xs font-semibold text-slate-500 dark:text-zinc-400 mb-2"
+          >
+            {day.slice(0, 1)}
+          </div>
+        ))}
+        {daysList.map((date, _idx) => {
+          const eventsOnDay = getEventsForDay(date);
+          const isCurrentMonth = isSameMonth(date, currentDate);
+          const hasEvents = eventsOnDay.length > 0;
+
+          return (
+            <button
+              type="button"
+              key={`day-${date.toISOString()}`}
+              onClick={() => {
+                if (hasEvents) {
+                  onSelectEventDay(date, eventsOnDay);
+                }
+              }}
+              className={`flex flex-col items-center relative aspect-square justify-center text-sm ${
+                isCurrentMonth
+                  ? "text-slate-900 dark:text-zinc-100"
+                  : "text-slate-300 dark:text-zinc-600"
+              }`}
+            >
+              <div
+                className={`flex items-center justify-center w-8 h-8 rounded-full ${
+                  hasEvents ? "bg-sky-100 dark:bg-sky-900" : ""
+                }`}
+              >
+                {format(date, "d")}
+              </div>
+              {hasEvents && (
+                <div className="absolute -bottom-3 flex space-x-0.5">
+                  {eventsOnDay.slice(0, 3).map((event) => (
+                    <div
+                      key={event.title}
+                      className="w-1.5 h-1.5 rounded-full bg-sky-700 dark:bg-sky-400"
+                    />
+                  ))}
+                </div>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default MobileCalendarView;

--- a/apps/next/src/components/ui/mobile-calendar-view.tsx
+++ b/apps/next/src/components/ui/mobile-calendar-view.tsx
@@ -90,35 +90,43 @@ const MobileCalendarView = ({
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
     >
-      <div className="flex items-center justify-between mb-6 px-2 w-full max-w-sm mx-auto">
-        <ArrowBackIosIcon
-          className="cursor-pointer text-slate-800 dark:text-zinc-200"
-          fontSize="small"
-          onClick={() => onDateChange(subMonths(currentDate, 1))}
-        />
-        <button
-          type="button"
-          className="text-2xl font-bold text-sky-700 dark:text-sky-400 focus:outline-none"
-          onClick={onOpenMonthPicker}
-        >
-          {format(currentDate, "MMMM yyyy")} <span className="text-sm">▼</span>
-        </button>
-        <ArrowForwardIosIcon
-          className="cursor-pointer text-slate-800 dark:text-zinc-200"
-          fontSize="small"
-          onClick={() => onDateChange(addMonths(currentDate, 1))}
-        />
+      <div className="bg-[#0069A833] dark:bg-sky-950 rounded-2xl px-4 py-4 w-full max-w-sm mx-auto mb-4">
+        <div className="flex items-center justify-between mb-4">
+          <button
+            type="button"
+            className="text-xl sm:text-2xl font-bold text-sky-700 dark:text-sky-400 focus:outline-none flex items-center gap-2"
+            onClick={onOpenMonthPicker}
+          >
+            {format(currentDate, "MMMM yyyy")}{" "}
+            <span className="text-xs sm:text-sm">▼</span>
+          </button>
+          <div className="flex items-center gap-5">
+            <ArrowBackIosIcon
+              className="cursor-pointer text-slate-500 dark:text-zinc-400"
+              fontSize="small"
+              onClick={() => onDateChange(subMonths(currentDate, 1))}
+            />
+            <ArrowForwardIosIcon
+              className="cursor-pointer text-slate-500 dark:text-zinc-400"
+              fontSize="small"
+              onClick={() => onDateChange(addMonths(currentDate, 1))}
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-7 gap-x-2 text-center">
+          {weekDays.map((day) => (
+            <div
+              key={`header-${day}`}
+              className="text-xs font-semibold text-slate-800 dark:text-zinc-300"
+            >
+              {day.slice(0, 1)}
+            </div>
+          ))}
+        </div>
       </div>
 
       <div className="grid grid-cols-7 gap-y-6 gap-x-2 text-center w-full max-w-sm mx-auto pb-10">
-        {weekDays.map((day) => (
-          <div
-            key={`header-${day}`}
-            className="text-xs font-semibold text-slate-500 dark:text-zinc-400 mb-2"
-          >
-            {day.slice(0, 1)}
-          </div>
-        ))}
         {daysList.map((date, _idx) => {
           const eventsOnDay = getEventsForDay(date);
           const isCurrentMonth = isSameMonth(date, currentDate);

--- a/apps/next/src/components/ui/mobile-calendar-view.tsx
+++ b/apps/next/src/components/ui/mobile-calendar-view.tsx
@@ -90,7 +90,7 @@ const MobileCalendarView = ({
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
     >
-      <div className="bg-[#0069A833] dark:bg-sky-950 rounded-2xl px-4 py-4 w-full max-w-sm mx-auto mb-4">
+      <div className="bg-[#0069A833] dark:bg-sky-950 rounded-2xl px-3 py-4 w-full mb-4">
         <div className="flex items-center justify-between mb-4">
           <button
             type="button"
@@ -114,7 +114,7 @@ const MobileCalendarView = ({
           </div>
         </div>
 
-        <div className="grid grid-cols-7 gap-x-2 text-center">
+        <div className="grid grid-cols-7 gap-x-1 text-center">
           {weekDays.map((day) => (
             <div
               key={`header-${day}`}
@@ -126,7 +126,7 @@ const MobileCalendarView = ({
         </div>
       </div>
 
-      <div className="grid grid-cols-7 gap-y-6 gap-x-2 text-center w-full max-w-sm mx-auto pb-10">
+      <div className="grid grid-cols-7 gap-y-6 gap-x-1 text-center w-full pb-10">
         {daysList.map((date, _idx) => {
           const eventsOnDay = getEventsForDay(date);
           const isCurrentMonth = isSameMonth(date, currentDate);
@@ -148,15 +148,18 @@ const MobileCalendarView = ({
                   : "text-slate-300 dark:text-zinc-600"
               }`}
             >
+              {isCurrentDate && (
+                <div className="absolute left-1/2 -translate-x-1/2 top-2 -bottom-6 w-10 rounded-lg bg-[#CCE1EE] dark:bg-sky-950 z-0" />
+              )}
               <div
-                className={`flex items-center justify-center w-8 h-8 rounded-full ${
-                  isCurrentDate ? "bg-sky-100 dark:bg-sky-900 font-bold" : ""
+                className={`relative z-10 flex items-center justify-center w-8 h-8 rounded-full ${
+                  isCurrentDate ? "font-semibold" : ""
                 }`}
               >
                 {format(date, "d")}
               </div>
               {hasEvents && (
-                <div className="absolute -bottom-3 flex space-x-0.5">
+                <div className="absolute z-10 -bottom-3 flex space-x-0.5">
                   {eventsOnDay.slice(0, 3).map((event) => (
                     <div
                       key={`${event.title}-${String(event.start)}-${event.restaurantId || event.location}`}

--- a/apps/next/src/components/ui/mobile-calendar-view.tsx
+++ b/apps/next/src/components/ui/mobile-calendar-view.tsx
@@ -8,6 +8,7 @@ import {
   format,
   isSameDay,
   isSameMonth,
+  isToday,
   startOfMonth,
   startOfWeek,
   subMonths,
@@ -122,6 +123,7 @@ const MobileCalendarView = ({
           const eventsOnDay = getEventsForDay(date);
           const isCurrentMonth = isSameMonth(date, currentDate);
           const hasEvents = eventsOnDay.length > 0;
+          const isCurrentDate = isToday(date);
 
           return (
             <button
@@ -140,7 +142,7 @@ const MobileCalendarView = ({
             >
               <div
                 className={`flex items-center justify-center w-8 h-8 rounded-full ${
-                  hasEvents ? "bg-sky-100 dark:bg-sky-900" : ""
+                  isCurrentDate ? "bg-sky-100 dark:bg-sky-900 font-bold" : ""
                 }`}
               >
                 {format(date, "d")}

--- a/apps/next/src/components/ui/mobile-calendar-view.tsx
+++ b/apps/next/src/components/ui/mobile-calendar-view.tsx
@@ -22,6 +22,7 @@ interface MobileCalendarViewProps {
   filteredEvents: EventInfo[];
   onSelectEventDay: (date: Date, events: EventInfo[]) => void;
   onOpenMonthPicker: () => void;
+  availableMonths: { year: number; monthIndex: number }[];
 }
 
 const MobileCalendarView = ({
@@ -30,7 +31,31 @@ const MobileCalendarView = ({
   filteredEvents,
   onSelectEventDay,
   onOpenMonthPicker,
+  availableMonths,
 }: MobileCalendarViewProps) => {
+  const currentYear = currentDate.getFullYear();
+  const currentMonthIndex = currentDate.getMonth();
+  const firstMonth = availableMonths[0];
+  const lastMonth = availableMonths[availableMonths.length - 1];
+  const atFirstMonth =
+    !firstMonth ||
+    currentYear < firstMonth.year ||
+    (currentYear === firstMonth.year &&
+      currentMonthIndex <= firstMonth.monthIndex);
+  const atLastMonth =
+    !lastMonth ||
+    currentYear > lastMonth.year ||
+    (currentYear === lastMonth.year &&
+      currentMonthIndex >= lastMonth.monthIndex);
+
+  const goPrev = () => {
+    if (atFirstMonth) return;
+    onDateChange(subMonths(currentDate, 1));
+  };
+  const goNext = () => {
+    if (atLastMonth) return;
+    onDateChange(addMonths(currentDate, 1));
+  };
   const [touchStart, setTouchStart] = useState<number | null>(null);
   const [touchEnd, setTouchEnd] = useState<number | null>(null);
 
@@ -53,10 +78,10 @@ const MobileCalendarView = ({
     const isRightSwipe = distance < -minSwipeDistance;
 
     if (isLeftSwipe) {
-      onDateChange(addMonths(currentDate, 1));
+      goNext();
     }
     if (isRightSwipe) {
-      onDateChange(subMonths(currentDate, 1));
+      goPrev();
     }
   };
 
@@ -102,14 +127,20 @@ const MobileCalendarView = ({
           </button>
           <div className="flex items-center gap-5">
             <ArrowBackIosIcon
-              className="cursor-pointer text-slate-500 dark:text-zinc-400"
+              className={`text-slate-500 dark:text-zinc-400 ${
+                atFirstMonth
+                  ? "opacity-30 cursor-not-allowed"
+                  : "cursor-pointer"
+              }`}
               fontSize="small"
-              onClick={() => onDateChange(subMonths(currentDate, 1))}
+              onClick={goPrev}
             />
             <ArrowForwardIosIcon
-              className="cursor-pointer text-slate-500 dark:text-zinc-400"
+              className={`text-slate-500 dark:text-zinc-400 ${
+                atLastMonth ? "opacity-30 cursor-not-allowed" : "cursor-pointer"
+              }`}
               fontSize="small"
-              onClick={() => onDateChange(addMonths(currentDate, 1))}
+              onClick={goNext}
             />
           </div>
         </div>

--- a/apps/next/src/components/ui/mobile-events-view.tsx
+++ b/apps/next/src/components/ui/mobile-events-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
+import CloseIcon from "@mui/icons-material/Close";
 import MenuIcon from "@mui/icons-material/Menu";
 import {
   FormControl,
@@ -10,6 +11,7 @@ import {
 } from "@mui/material";
 import Drawer from "@mui/material/Drawer";
 import { useState } from "react";
+import { getEventType } from "@/utils/funcs";
 import { HallEnum } from "@/utils/types";
 import type { EventInfo } from "./card/event-card";
 import EventDrawerContent from "./event-drawer-content";
@@ -48,6 +50,7 @@ const MobileEventsView = ({
 }: MobileEventsViewProps) => {
   const [mobileView, setMobileView] = useState<"calendar" | "list">("calendar");
   const [monthPickerOpen, setMonthPickerOpen] = useState(false);
+  const [selectedDayEvents, setSelectedDayEvents] = useState<EventInfo[]>([]);
 
   const locationFormControlClasses =
     "w-36 [&_.MuiOutlinedInput-root]:h-[38px] [&_.MuiOutlinedInput-root]:rounded-lg [&_.MuiOutlinedInput-root]:bg-white [&_.MuiOutlinedInput-root]:text-[0.9rem] [&_.MuiOutlinedInput-root]:text-slate-900 [&_.MuiOutlinedInput-notchedOutline]:border-sky-700 [&_.MuiOutlinedInput-root:hover_.MuiOutlinedInput-notchedOutline]:border-sky-800 [&_.MuiOutlinedInput-root.Mui-focused_.MuiOutlinedInput-notchedOutline]:border-2 [&_.MuiOutlinedInput-root.Mui-focused_.MuiOutlinedInput-notchedOutline]:border-sky-700";
@@ -124,13 +127,29 @@ const MobileEventsView = ({
             onDateChange={setCurrentDate}
             filteredEvents={filteredEvents}
             onSelectEventDay={(_date, eventsForDay) => {
-              // Expand day behavior could either show list or directly a drawer if 1 item.
-              // Assuming it jumps to list view mapped to that day, or opens a modal.
-              // For now we pass the first event to the standard details drawer logic.
               if (eventsForDay.length > 0) {
-                // Re-wrap to expected resource structure
-                const evt = { resource: eventsForDay[0] };
-                handleSelectEvent(evt);
+                const now = new Date();
+                const mappedEvents = (eventsForDay as any[]).map(
+                  (resource) =>
+                    ({
+                      name: (resource.title as string) || "",
+                      shortDesc: (resource.shortDescription as string) || "",
+                      longDesc: (resource.longDescription as string) || "",
+                      imgSrc: (resource.image as string) || "",
+                      alt: `${(resource.title as string) || ""} promotion image`,
+                      startTime: new Date(resource.start),
+                      endTime: new Date(resource.end),
+                      location:
+                        (resource.restaurantId as string) === "anteatery"
+                          ? HallEnum.ANTEATERY
+                          : HallEnum.BRANDYWINE,
+                      isOngoing:
+                        new Date(resource.start) <= now &&
+                        new Date(resource.end) >= now,
+                      type: getEventType((resource.title as string) || ""),
+                    }) as EventInfo,
+                );
+                setSelectedDayEvents(mappedEvents);
               }
             }}
             onOpenMonthPicker={() => setMonthPickerOpen(true)}
@@ -161,17 +180,58 @@ const MobileEventsView = ({
       {/* Event Details Drawer */}
       <Drawer
         anchor="bottom"
-        open={Boolean(selectedEventData)}
-        onClose={handleClose}
+        open={Boolean(selectedEventData) || selectedDayEvents.length > 0}
+        onClose={() => {
+          handleClose();
+          setSelectedDayEvents([]);
+        }}
         sx={{
           "& .MuiDrawer-paper": {
             borderTopLeftRadius: "10px",
             borderTopRightRadius: "10px",
             height: "auto",
+            maxHeight: "90vh",
+            backgroundColor:
+              selectedDayEvents.length === 1 ? "white" : "#f8fafc",
           },
         }}
+        className="dark:[&_.MuiDrawer-paper]:!bg-zinc-950"
       >
-        {selectedEventData && <EventDrawerContent {...selectedEventData} />}
+        <div className="relative w-full h-full flex flex-col overflow-y-auto">
+          {(Boolean(selectedEventData) || selectedDayEvents.length > 0) && (
+            <button
+              type="button"
+              className="absolute top-3 right-4 z-50 bg-white/80 dark:bg-zinc-900/80 backdrop-blur rounded-full p-1 shadow hover:bg-white dark:hover:bg-zinc-800 transition-colors"
+              onClick={() => {
+                handleClose();
+                setSelectedDayEvents([]);
+              }}
+            >
+              <CloseIcon
+                className="text-zinc-600 dark:text-zinc-300"
+                fontSize="small"
+              />
+            </button>
+          )}
+
+          {selectedEventData ? (
+            <EventDrawerContent {...selectedEventData} />
+          ) : selectedDayEvents.length === 1 ? (
+            <EventDrawerContent {...selectedDayEvents[0]} />
+          ) : (
+            <div className="flex flex-col gap-4 p-4 pt-12 pb-10">
+              {selectedDayEvents.map((event, idx) => (
+                <div
+                  // biome-ignore lint/suspicious/noArrayIndexKey: list events lack unique IDs and are statically ordered
+                  key={`event-drawer-${event.name}-${idx}`}
+                  className="bg-white dark:bg-zinc-900 rounded-xl overflow-hidden shadow-sm border border-slate-200 dark:border-zinc-800"
+                >
+                  <EventDrawerContent {...event} />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
       </Drawer>
     </div>
   );

--- a/apps/next/src/components/ui/mobile-events-view.tsx
+++ b/apps/next/src/components/ui/mobile-events-view.tsx
@@ -61,8 +61,8 @@ const MobileEventsView = ({
               onChange={handleLocationChange}
             >
               <MenuItem value="both">All Locations</MenuItem>
-              <MenuItem value={HallEnum.BRANDYWINE}>Brandywine</MenuItem>
-              <MenuItem value={HallEnum.ANTEATERY}>The Anteatery</MenuItem>
+              <MenuItem value="brandywine">Brandywine</MenuItem>
+              <MenuItem value="anteatery">Anteatery</MenuItem>
             </Select>
           </FormControl>
 

--- a/apps/next/src/components/ui/mobile-events-view.tsx
+++ b/apps/next/src/components/ui/mobile-events-view.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
+import MenuIcon from "@mui/icons-material/Menu";
+import { FormControl, MenuItem, Select } from "@mui/material";
+import Drawer from "@mui/material/Drawer";
+import { useState } from "react";
+import { HallEnum } from "@/utils/types";
+import type { EventInfo } from "./card/event-card";
+import EventDrawerContent from "./event-drawer-content";
+import MobileCalendarView from "./mobile-calendar-view";
+import MobileListView from "./mobile-list-view";
+import MonthPickerDrawer from "./month-picker-drawer";
+
+interface MobileEventsViewProps {
+  selectedDiningHall: "both" | "anteatery" | "brandywine";
+  handleLocationChange: (event: unknown) => void;
+  isLoading: boolean;
+  error: Error | null;
+  filteredEvents: EventInfo[];
+  currentDate: Date;
+  setCurrentDate: (date: Date) => void;
+  selectedEventData: EventInfo | null;
+  handleSelectEvent: (calendarEvent: { resource: EventInfo }) => void;
+  handleClose: () => void;
+}
+
+const MobileEventsView = ({
+  selectedDiningHall,
+  handleLocationChange,
+  isLoading,
+  error,
+  filteredEvents,
+  currentDate,
+  setCurrentDate,
+  selectedEventData,
+  handleSelectEvent,
+  handleClose,
+}: MobileEventsViewProps) => {
+  const [mobileView, setMobileView] = useState<"calendar" | "list">("calendar");
+  const [monthPickerOpen, setMonthPickerOpen] = useState(false);
+
+  const locationFormControlClasses =
+    "w-36 [&_.MuiOutlinedInput-root]:h-[38px] [&_.MuiOutlinedInput-root]:rounded-lg [&_.MuiOutlinedInput-root]:bg-white [&_.MuiOutlinedInput-root]:text-[0.9rem] [&_.MuiOutlinedInput-root]:text-slate-900 [&_.MuiOutlinedInput-notchedOutline]:border-sky-700 [&_.MuiOutlinedInput-root:hover_.MuiOutlinedInput-notchedOutline]:border-sky-800 [&_.MuiOutlinedInput-root.Mui-focused_.MuiOutlinedInput-notchedOutline]:border-2 [&_.MuiOutlinedInput-root.Mui-focused_.MuiOutlinedInput-notchedOutline]:border-sky-700";
+  const locationSelectClasses =
+    "[&_.MuiSelect-select]:!py-2 [&_.MuiSelect-select]:!pl-3 [&_.MuiSelect-select]:!pr-6 [&_.MuiSelect-icon]:right-1 [&_.MuiSelect-icon]:text-sky-700";
+
+  return (
+    <div className="flex flex-col h-screen w-full bg-white dark:bg-zinc-950 overflow-hidden font-sans">
+      {/* HEADER */}
+      <div className="flex flex-col px-4 pt-12 pb-4 bg-white dark:bg-zinc-950 z-20">
+        <h1 className="text-4xl font-bold text-sky-700 dark:text-sky-400 mb-4">
+          Events
+        </h1>
+        <div className="flex items-center gap-3">
+          <FormControl className={locationFormControlClasses}>
+            <Select
+              id="mobile-location-select"
+              className={locationSelectClasses}
+              value={selectedDiningHall}
+              onChange={handleLocationChange}
+            >
+              <MenuItem value="both">All Locations</MenuItem>
+              <MenuItem value={HallEnum.BRANDYWINE}>Brandywine</MenuItem>
+              <MenuItem value={HallEnum.ANTEATERY}>The Anteatery</MenuItem>
+            </Select>
+          </FormControl>
+
+          {/* View Toggle */}
+          <div className="flex bg-white dark:bg-zinc-900 border border-sky-700 dark:border-sky-500 rounded-lg overflow-hidden h-[38px]">
+            <button
+              type="button"
+              onClick={() => setMobileView("calendar")}
+              className={`px-3 flex items-center justify-center transition-colors ${
+                mobileView === "calendar"
+                  ? "bg-sky-700 text-white"
+                  : "text-sky-700 hover:bg-sky-50 dark:hover:bg-zinc-800"
+              }`}
+            >
+              <CalendarTodayIcon fontSize="small" />
+            </button>
+            <div className="w-[1px] bg-sky-700 dark:bg-sky-500 h-full" />
+            <button
+              type="button"
+              onClick={() => setMobileView("list")}
+              className={`px-3 flex items-center justify-center transition-colors ${
+                mobileView === "list"
+                  ? "bg-sky-700 text-white"
+                  : "text-sky-700 hover:bg-sky-50 dark:hover:bg-zinc-800"
+              }`}
+            >
+              <MenuIcon fontSize="small" />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {isLoading && (
+        <div className="flex-1 flex items-center justify-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-sky-700"></div>
+        </div>
+      )}
+      {error && (
+        <div className="flex-1 flex flex-col px-4 text-red-500 text-center justify-center">
+          <p>Error loading data: {error.message}</p>
+        </div>
+      )}
+
+      {/* CONTENT */}
+      {!isLoading &&
+        !error &&
+        (mobileView === "calendar" ? (
+          <MobileCalendarView
+            currentDate={currentDate}
+            onDateChange={setCurrentDate}
+            filteredEvents={filteredEvents}
+            onSelectEventDay={(_date, eventsForDay) => {
+              // Expand day behavior could either show list or directly a drawer if 1 item.
+              // Assuming it jumps to list view mapped to that day, or opens a modal.
+              // For now we pass the first event to the standard details drawer logic.
+              if (eventsForDay.length > 0) {
+                // Re-wrap to expected resource structure
+                const evt = { resource: eventsForDay[0] };
+                handleSelectEvent(evt);
+              }
+            }}
+            onOpenMonthPicker={() => setMonthPickerOpen(true)}
+          />
+        ) : (
+          <MobileListView
+            currentDate={currentDate}
+            onDateChange={setCurrentDate}
+            filteredEvents={filteredEvents}
+            onOpenMonthPicker={() => setMonthPickerOpen(true)}
+            onSelectEvent={(evtInfo) =>
+              handleSelectEvent({ resource: evtInfo })
+            }
+          />
+        ))}
+
+      {/* Month Picker Drawer */}
+      <MonthPickerDrawer
+        open={monthPickerOpen}
+        onClose={() => setMonthPickerOpen(false)}
+        currentDate={currentDate}
+        onSelectMonth={(year, monthIndex) => {
+          setCurrentDate(new Date(year, monthIndex, 1));
+          setMonthPickerOpen(false);
+        }}
+      />
+
+      {/* Event Details Drawer */}
+      <Drawer
+        anchor="bottom"
+        open={Boolean(selectedEventData)}
+        onClose={handleClose}
+        sx={{
+          "& .MuiDrawer-paper": {
+            borderTopLeftRadius: "10px",
+            borderTopRightRadius: "10px",
+            height: "auto",
+          },
+        }}
+      >
+        {selectedEventData && <EventDrawerContent {...selectedEventData} />}
+      </Drawer>
+    </div>
+  );
+};
+
+export default MobileEventsView;

--- a/apps/next/src/components/ui/mobile-events-view.tsx
+++ b/apps/next/src/components/ui/mobile-events-view.tsx
@@ -2,7 +2,12 @@
 
 import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
 import MenuIcon from "@mui/icons-material/Menu";
-import { FormControl, MenuItem, Select } from "@mui/material";
+import {
+  FormControl,
+  MenuItem,
+  Select,
+  type SelectChangeEvent,
+} from "@mui/material";
 import Drawer from "@mui/material/Drawer";
 import { useState } from "react";
 import { HallEnum } from "@/utils/types";
@@ -14,14 +19,18 @@ import MonthPickerDrawer from "./month-picker-drawer";
 
 interface MobileEventsViewProps {
   selectedDiningHall: "both" | "anteatery" | "brandywine";
-  handleLocationChange: (event: unknown) => void;
+  handleLocationChange: (
+    event: SelectChangeEvent<"both" | "anteatery" | "brandywine">,
+  ) => void;
   isLoading: boolean;
   error: Error | null;
   filteredEvents: EventInfo[];
   currentDate: Date;
   setCurrentDate: (date: Date) => void;
   selectedEventData: EventInfo | null;
-  handleSelectEvent: (calendarEvent: { resource: EventInfo }) => void;
+  handleSelectEvent: (calendarEvent: {
+    resource: Record<string, unknown>;
+  }) => void;
   handleClose: () => void;
 }
 

--- a/apps/next/src/components/ui/mobile-events-view.tsx
+++ b/apps/next/src/components/ui/mobile-events-view.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
-import CloseIcon from "@mui/icons-material/Close";
 import MenuIcon from "@mui/icons-material/Menu";
 import {
   FormControl,
@@ -9,12 +8,11 @@ import {
   Select,
   type SelectChangeEvent,
 } from "@mui/material";
-import Drawer from "@mui/material/Drawer";
 import { useState } from "react";
 import { getEventType } from "@/utils/funcs";
 import { HallEnum } from "@/utils/types";
 import type { EventInfo } from "./card/event-card";
-import EventDrawerContent from "./event-drawer-content";
+import EventDetailsDrawer from "./event-details-drawer";
 import MobileCalendarView from "./mobile-calendar-view";
 import MobileListView from "./mobile-list-view";
 import MonthPickerDrawer from "./month-picker-drawer";
@@ -27,6 +25,7 @@ interface MobileEventsViewProps {
   isLoading: boolean;
   error: Error | null;
   filteredEvents: EventInfo[];
+  filteredUpcomingEvents: EventInfo[];
   currentDate: Date;
   setCurrentDate: (date: Date) => void;
   selectedEventData: EventInfo | null;
@@ -34,6 +33,7 @@ interface MobileEventsViewProps {
     resource: Record<string, unknown>;
   }) => void;
   handleClose: () => void;
+  availableMonths: { year: number; monthIndex: number }[];
 }
 
 const MobileEventsView = ({
@@ -42,11 +42,13 @@ const MobileEventsView = ({
   isLoading,
   error,
   filteredEvents,
+  filteredUpcomingEvents,
   currentDate,
   setCurrentDate,
   selectedEventData,
   handleSelectEvent,
   handleClose,
+  availableMonths,
 }: MobileEventsViewProps) => {
   const [mobileView, setMobileView] = useState<"calendar" | "list">("calendar");
   const [monthPickerOpen, setMonthPickerOpen] = useState(false);
@@ -57,9 +59,13 @@ const MobileEventsView = ({
   const locationSelectClasses =
     "[&_.MuiSelect-select]:!py-2 [&_.MuiSelect-select]:!pl-3 [&_.MuiSelect-select]:!pr-6 [&_.MuiSelect-icon]:right-1 [&_.MuiSelect-icon]:text-sky-700";
 
+  const handleEventDrawerClose = () => {
+    handleClose();
+    setSelectedDayEvents([]);
+  };
+
   return (
     <div className="flex flex-col h-screen w-full bg-white dark:bg-zinc-950 overflow-hidden font-sans">
-      {/* HEADER */}
       <div className="flex flex-col px-4 pt-12 pb-4 bg-white dark:bg-zinc-950 z-20">
         <h1 className="text-4xl font-bold text-sky-700 dark:text-sky-400 mb-4">
           Events
@@ -78,7 +84,6 @@ const MobileEventsView = ({
             </Select>
           </FormControl>
 
-          {/* View Toggle */}
           <div className="flex bg-white dark:bg-zinc-900 border border-sky-700 dark:border-sky-500 rounded-lg overflow-hidden h-[38px]">
             <button
               type="button"
@@ -118,7 +123,6 @@ const MobileEventsView = ({
         </div>
       )}
 
-      {/* CONTENT */}
       {!isLoading &&
         !error &&
         (mobileView === "calendar" ? (
@@ -129,7 +133,9 @@ const MobileEventsView = ({
             onSelectEventDay={(_date, eventsForDay) => {
               if (eventsForDay.length > 0) {
                 const now = new Date();
-                const mappedEvents = (eventsForDay as any[]).map(
+                const mappedEvents = (
+                  eventsForDay as unknown as Record<string, unknown>[]
+                ).map(
                   (resource) =>
                     ({
                       name: (resource.title as string) || "",
@@ -158,7 +164,7 @@ const MobileEventsView = ({
           <MobileListView
             currentDate={currentDate}
             onDateChange={setCurrentDate}
-            filteredEvents={filteredEvents}
+            filteredEvents={filteredUpcomingEvents}
             onOpenMonthPicker={() => setMonthPickerOpen(true)}
             onSelectEvent={(evtInfo) =>
               handleSelectEvent({ resource: evtInfo })
@@ -166,73 +172,22 @@ const MobileEventsView = ({
           />
         ))}
 
-      {/* Month Picker Drawer */}
       <MonthPickerDrawer
         open={monthPickerOpen}
         onClose={() => setMonthPickerOpen(false)}
         currentDate={currentDate}
+        availableMonths={availableMonths}
         onSelectMonth={(year, monthIndex) => {
           setCurrentDate(new Date(year, monthIndex, 1));
           setMonthPickerOpen(false);
         }}
       />
 
-      {/* Event Details Drawer */}
-      <Drawer
-        anchor="bottom"
-        open={Boolean(selectedEventData) || selectedDayEvents.length > 0}
-        onClose={() => {
-          handleClose();
-          setSelectedDayEvents([]);
-        }}
-        sx={{
-          "& .MuiDrawer-paper": {
-            borderTopLeftRadius: "10px",
-            borderTopRightRadius: "10px",
-            height: "auto",
-            maxHeight: "90vh",
-            backgroundColor:
-              selectedDayEvents.length === 1 ? "white" : "#f8fafc",
-          },
-        }}
-        className="dark:[&_.MuiDrawer-paper]:!bg-zinc-950"
-      >
-        <div className="relative w-full h-full flex flex-col overflow-y-auto">
-          {(Boolean(selectedEventData) || selectedDayEvents.length > 0) && (
-            <button
-              type="button"
-              className="absolute top-3 right-4 z-50 bg-white/80 dark:bg-zinc-900/80 backdrop-blur rounded-full p-1 shadow hover:bg-white dark:hover:bg-zinc-800 transition-colors"
-              onClick={() => {
-                handleClose();
-                setSelectedDayEvents([]);
-              }}
-            >
-              <CloseIcon
-                className="text-zinc-600 dark:text-zinc-300"
-                fontSize="small"
-              />
-            </button>
-          )}
-
-          {selectedEventData ? (
-            <EventDrawerContent {...selectedEventData} />
-          ) : selectedDayEvents.length === 1 ? (
-            <EventDrawerContent {...selectedDayEvents[0]} />
-          ) : (
-            <div className="flex flex-col gap-4 p-4 pt-12 pb-10">
-              {selectedDayEvents.map((event, idx) => (
-                <div
-                  // biome-ignore lint/suspicious/noArrayIndexKey: list events lack unique IDs and are statically ordered
-                  key={`event-drawer-${event.name}-${idx}`}
-                  className="bg-white dark:bg-zinc-900 rounded-xl overflow-hidden shadow-sm border border-slate-200 dark:border-zinc-800"
-                >
-                  <EventDrawerContent {...event} />
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      </Drawer>
+      <EventDetailsDrawer
+        selectedEventData={selectedEventData}
+        selectedDayEvents={selectedDayEvents}
+        onClose={handleEventDrawerClose}
+      />
     </div>
   );
 };

--- a/apps/next/src/components/ui/mobile-events-view.tsx
+++ b/apps/next/src/components/ui/mobile-events-view.tsx
@@ -130,6 +130,7 @@ const MobileEventsView = ({
             currentDate={currentDate}
             onDateChange={setCurrentDate}
             filteredEvents={filteredEvents}
+            availableMonths={availableMonths}
             onSelectEventDay={(_date, eventsForDay) => {
               if (eventsForDay.length > 0) {
                 const now = new Date();

--- a/apps/next/src/components/ui/mobile-list-event-row.tsx
+++ b/apps/next/src/components/ui/mobile-list-event-row.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import LocationOnOutlinedIcon from "@mui/icons-material/LocationOnOutlined";
+import { format } from "date-fns";
+import type { EventInfo } from "./card/event-card";
+
+interface MobileListEventRowProps {
+  event: EventInfo;
+  onClick: () => void;
+}
+
+const ROW_CLASSES = [
+  "flex flex-row justify-between items-center",
+  "py-2 px-3 text-left w-full",
+  "border-b last:border-0 border-slate-100 dark:border-zinc-800",
+  "hover:bg-slate-50 dark:hover:bg-zinc-900/50 transition-colors",
+].join(" ");
+
+const MobileListEventRow = ({ event, onClick }: MobileListEventRowProps) => {
+  const startStr = format(new Date(event.start), "h:mm a");
+  const endStr = format(new Date(event.end), "h:mm a");
+  const locationLabel =
+    event.restaurantId === "anteatery" ? "Anteatery" : "Brandywine";
+
+  return (
+    <button type="button" className={ROW_CLASSES} onClick={onClick}>
+      <div className="flex flex-col">
+        <span className="font-medium text-black dark:text-zinc-200">
+          {event.title}
+        </span>
+        <span className="text-gray-500 flex items-center mt-0.5">
+          <LocationOnOutlinedIcon sx={{ fontSize: 14 }} className="mr-0.5" />
+          {locationLabel}
+        </span>
+      </div>
+      <div className="flex flex-col items-end text-sm text-black dark:text-zinc-400">
+        <span>{startStr}</span>
+        <span>{endStr}</span>
+      </div>
+    </button>
+  );
+};
+
+export default MobileListEventRow;

--- a/apps/next/src/components/ui/mobile-list-view.tsx
+++ b/apps/next/src/components/ui/mobile-list-view.tsx
@@ -2,10 +2,10 @@
 
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
-import LocationOnOutlinedIcon from "@mui/icons-material/LocationOnOutlined";
-import { addMonths, format, isSameDay, startOfDay, subMonths } from "date-fns";
-import { useMemo, useState } from "react";
+import { format, isSameDay, startOfDay } from "date-fns";
+import { useMemo, useRef } from "react";
 import type { EventInfo } from "./card/event-card";
+import MobileListEventRow from "./mobile-list-event-row";
 
 interface MobileListViewProps {
   currentDate: Date;
@@ -15,167 +15,141 @@ interface MobileListViewProps {
   onSelectEvent: (event: EventInfo) => void;
 }
 
+interface DayGroup {
+  date: Date;
+  events: EventInfo[];
+}
+
+interface MonthGroup {
+  key: string;
+  date: Date;
+  days: DayGroup[];
+}
+
 const MobileListView = ({
-  currentDate,
-  onDateChange,
   filteredEvents,
   onOpenMonthPicker,
   onSelectEvent,
 }: MobileListViewProps) => {
-  const [touchStart, setTouchStart] = useState<number | null>(null);
-  const [touchEnd, setTouchEnd] = useState<number | null>(null);
+  const monthRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
-  // Minimum swipe distance (in px)
-  const minSwipeDistance = 50;
-
-  const handleTouchStart = (e: React.TouchEvent) => {
-    setTouchEnd(null);
-    setTouchStart(e.targetTouches[0].clientX);
-  };
-
-  const handleTouchMove = (e: React.TouchEvent) => {
-    setTouchEnd(e.targetTouches[0].clientX);
-  };
-
-  const handleTouchEnd = () => {
-    if (!touchStart || !touchEnd) return;
-    const distance = touchStart - touchEnd;
-    const isLeftSwipe = distance > minSwipeDistance;
-    const isRightSwipe = distance < -minSwipeDistance;
-
-    if (isLeftSwipe) {
-      onDateChange(addMonths(currentDate, 1));
-    }
-    if (isRightSwipe) {
-      onDateChange(subMonths(currentDate, 1));
-    }
-  };
-
-  const groupedEvents = useMemo(() => {
-    // Sort events just in case
+  const monthGroups = useMemo<MonthGroup[]>(() => {
     const sorted = [...filteredEvents].sort(
       (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
     );
 
-    const groups: { [key: string]: { date: Date; events: EventInfo[] } } = {};
+    const months: Record<string, MonthGroup> = {};
     sorted.forEach((event) => {
-      const dateKey = format(startOfDay(new Date(event.start)), "yyyy-MM-dd");
-      if (!groups[dateKey]) {
-        groups[dateKey] = { date: new Date(event.start), events: [] };
+      const start = new Date(event.start);
+      const monthKey = format(start, "yyyy-MM");
+      if (!months[monthKey]) {
+        months[monthKey] = { key: monthKey, date: start, days: [] };
       }
-      groups[dateKey].events.push(event);
+      const dayKey = format(startOfDay(start), "yyyy-MM-dd");
+      const existingDay = months[monthKey].days.find(
+        (d) => format(d.date, "yyyy-MM-dd") === dayKey,
+      );
+      if (existingDay) {
+        existingDay.events.push(event);
+      } else {
+        months[monthKey].days.push({ date: start, events: [event] });
+      }
     });
 
-    // Extract grouped arrays, sort chronologically
-    return Object.values(groups).sort(
+    return Object.values(months).sort(
       (a, b) => a.date.getTime() - b.date.getTime(),
     );
   }, [filteredEvents]);
 
-  const monthLabel = format(currentDate, "MMMM yyyy");
+  const scrollToMonth = (offset: number) => (currentKey: string) => {
+    const idx = monthGroups.findIndex((m) => m.key === currentKey);
+    const target = monthGroups[idx + offset];
+    if (target) {
+      monthRefs.current[target.key]?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }
+  };
+
+  const goPrev = scrollToMonth(-1);
+  const goNext = scrollToMonth(1);
 
   return (
-    <div
-      className="flex flex-col flex-1 px-4 mt-2 mb-20 overflow-y-auto"
-      onTouchStart={handleTouchStart}
-      onTouchMove={handleTouchMove}
-      onTouchEnd={handleTouchEnd}
-    >
-      {/* Scrollable Month Header */}
-      <div className="sticky top-0 z-10 bg-white/95 dark:bg-zinc-950/95 backdrop-blur py-2">
-        <div className="bg-[#CCE1EE] dark:bg-sky-950 rounded-2xl px-4 py-4 w-full mx-auto">
-          <div className="flex items-center justify-between">
-            <button
-              type="button"
-              className="text-xl sm:text-2xl font-bold text-sky-700 dark:text-sky-400 focus:outline-none flex items-center gap-2"
-              onClick={onOpenMonthPicker}
-            >
-              {monthLabel} <span className="text-xs sm:text-sm">▼</span>
-            </button>
-            <div className="flex items-center gap-5">
-              <ArrowBackIosIcon
-                className="cursor-pointer text-slate-500 dark:text-zinc-400 focus:outline-none"
-                fontSize="small"
-                onClick={() => onDateChange(subMonths(currentDate, 1))}
-              />
-              <ArrowForwardIosIcon
-                className="cursor-pointer text-slate-500 dark:text-zinc-400 focus:outline-none"
-                fontSize="small"
-                onClick={() => onDateChange(addMonths(currentDate, 1))}
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-6 mt-4">
-        {groupedEvents.length === 0 ? (
-          <p className="text-center text-zinc-500 py-10">
-            No events this month.
-          </p>
-        ) : (
-          groupedEvents.map((group) => {
-            const isToday = isSameDay(group.date, new Date());
-
-            return (
-              <div
-                key={group.date.toISOString()}
-                className="flex flex-col gap-3"
-              >
-                {/* Date Header */}
+    <div className="flex flex-col flex-1 px-4 mt-2 mb-20 overflow-y-auto">
+      {monthGroups.length === 0 ? (
+        <p className="text-center text-zinc-500 py-10">No upcoming events.</p>
+      ) : (
+        monthGroups.map((month) => (
+          <div
+            key={month.key}
+            ref={(el) => {
+              monthRefs.current[month.key] = el;
+            }}
+            className="flex flex-col"
+          >
+            <div className="sticky top-0 z-10 bg-white dark:bg-zinc-950 py-2">
+              <div className="bg-[#CCE1EE] dark:bg-sky-950 rounded-2xl px-4 py-4 w-full mx-auto">
                 <div className="flex items-center justify-between">
-                  <h3 className="font-semibold text-black dark:text-zinc-100">
-                    {format(group.date, "EEEE - MMMM d, yyyy")}
-                  </h3>
-                  {isToday && (
-                    <span className="bg-sky-700 text-white text-[10px] font-bold px-2 py-0.5 rounded">
-                      Today
-                    </span>
-                  )}
-                </div>
-
-                {/* Day's Events */}
-                <div className="flex flex-col gap-0 border-l-[3px] border-sky-700 dark:border-sky-500 ml-1">
-                  {group.events.map((event, idx) => {
-                    const startStr = format(new Date(event.start), "h:mm a");
-                    const endStr = format(new Date(event.end), "h:mm a");
-                    const locationLabel =
-                      event.restaurantId === "anteatery"
-                        ? "Anteatery"
-                        : "Brandywine";
-
-                    return (
-                      <button
-                        type="button"
-                        key={`${event.title}-${String(event.start)}-${event.restaurantId || idx}`}
-                        className="flex flex-row justify-between items-center py-2 px-3 text-left hover:bg-slate-50 dark:hover:bg-zinc-900/50 transition-colors border-b last:border-0 border-slate-100 dark:border-zinc-800 w-full"
-                        onClick={() => onSelectEvent(event)}
-                      >
-                        <div className="flex flex-col">
-                          <span className="font-medium text-black dark:text-zinc-200">
-                            {event.title}
-                          </span>
-                          <span className="text-gray-500 flex items-center mt-0.5">
-                            <LocationOnOutlinedIcon
-                              sx={{ fontSize: 14 }}
-                              className="mr-0.5"
-                            />
-                            {locationLabel}
-                          </span>
-                        </div>
-                        <div className="flex flex-col items-end text-sm text-black dark:text-zinc-400">
-                          <span>{startStr}</span>
-                          <span>{endStr}</span>
-                        </div>
-                      </button>
-                    );
-                  })}
+                  <button
+                    type="button"
+                    className="text-xl sm:text-2xl font-bold text-sky-700 dark:text-sky-400 focus:outline-none flex items-center gap-2"
+                    onClick={onOpenMonthPicker}
+                  >
+                    {format(month.date, "MMMM yyyy")}{" "}
+                    <span className="text-xs sm:text-sm">▼</span>
+                  </button>
+                  <div className="flex items-center gap-5">
+                    <ArrowBackIosIcon
+                      className="cursor-pointer text-slate-500 dark:text-zinc-400 focus:outline-none"
+                      fontSize="small"
+                      onClick={() => goPrev(month.key)}
+                    />
+                    <ArrowForwardIosIcon
+                      className="cursor-pointer text-slate-500 dark:text-zinc-400 focus:outline-none"
+                      fontSize="small"
+                      onClick={() => goNext(month.key)}
+                    />
+                  </div>
                 </div>
               </div>
-            );
-          })
-        )}
-      </div>
+            </div>
+
+            <div className="flex flex-col gap-6 mt-2 mb-4">
+              {month.days.map((day) => {
+                const isToday = isSameDay(day.date, new Date());
+                return (
+                  <div
+                    key={day.date.toISOString()}
+                    className="flex flex-col gap-3"
+                  >
+                    <div className="flex items-center justify-between">
+                      <h3 className="font-semibold text-black dark:text-zinc-100">
+                        {format(day.date, "EEEE - MMMM d, yyyy")}
+                      </h3>
+                      {isToday && (
+                        <span className="bg-sky-700 text-white text-[10px] font-bold px-2 py-0.5 rounded">
+                          Today
+                        </span>
+                      )}
+                    </div>
+
+                    <div className="flex flex-col gap-0 border-l-[3px] border-sky-700 dark:border-sky-500 ml-1">
+                      {day.events.map((event, idx) => (
+                        <MobileListEventRow
+                          key={`${event.title}-${String(event.start)}-${event.restaurantId || idx}`}
+                          event={event}
+                          onClick={() => onSelectEvent(event)}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))
+      )}
     </div>
   );
 };

--- a/apps/next/src/components/ui/mobile-list-view.tsx
+++ b/apps/next/src/components/ui/mobile-list-view.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import LocationOnOutlinedIcon from "@mui/icons-material/LocationOnOutlined";
+import { format, isSameDay, startOfDay } from "date-fns";
+import { useMemo } from "react";
+import type { EventInfo } from "./card/event-card";
+
+interface MobileListViewProps {
+  currentDate: Date;
+  onDateChange: (date: Date) => void;
+  filteredEvents: EventInfo[];
+  onOpenMonthPicker: () => void;
+  onSelectEvent: (event: EventInfo) => void;
+}
+
+const MobileListView = ({
+  currentDate,
+  onDateChange: _onDateChange,
+  filteredEvents,
+  onOpenMonthPicker,
+  onSelectEvent,
+}: MobileListViewProps) => {
+  const groupedEvents = useMemo(() => {
+    // Sort events just in case
+    const sorted = [...filteredEvents].sort(
+      (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
+    );
+
+    const groups: { [key: string]: { date: Date; events: EventInfo[] } } = {};
+    sorted.forEach((event) => {
+      const dateKey = format(startOfDay(new Date(event.start)), "yyyy-MM-dd");
+      if (!groups[dateKey]) {
+        groups[dateKey] = { date: new Date(event.start), events: [] };
+      }
+      groups[dateKey].events.push(event);
+    });
+
+    // Extract grouped arrays, sort chronologically
+    return Object.values(groups).sort(
+      (a, b) => a.date.getTime() - b.date.getTime(),
+    );
+  }, [filteredEvents]);
+
+  const monthLabel = format(currentDate, "MMMM yyyy");
+
+  return (
+    <div className="flex flex-col flex-1 px-4 mt-2 mb-20 overflow-y-auto">
+      {/* Scrollable Month Header */}
+      <div className="sticky top-0 z-10 bg-white/95 dark:bg-zinc-950/95 backdrop-blur py-2">
+        <button
+          type="button"
+          onClick={onOpenMonthPicker}
+          className="flex items-center gap-2 px-4 py-2 bg-sky-100/50 dark:bg-sky-900/30 rounded-full text-sky-800 dark:text-sky-300 font-semibold"
+        >
+          {monthLabel} <span className="text-xs">▼</span>
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-6 mt-4">
+        {groupedEvents.length === 0 ? (
+          <p className="text-center text-zinc-500 py-10">
+            No events this month.
+          </p>
+        ) : (
+          groupedEvents.map((group) => {
+            const isToday = isSameDay(group.date, new Date());
+
+            return (
+              <div
+                key={group.date.toISOString()}
+                className="flex flex-col gap-3"
+              >
+                {/* Date Header */}
+                <div className="flex items-center justify-between">
+                  <h3 className="font-bold text-slate-900 dark:text-zinc-100">
+                    {format(group.date, "EEEE - MMMM d, yyyy")}
+                  </h3>
+                  {isToday && (
+                    <span className="bg-sky-700 text-white text-[10px] font-bold px-2 py-0.5 rounded">
+                      Today
+                    </span>
+                  )}
+                </div>
+
+                {/* Day's Events */}
+                <div className="flex flex-col gap-0 border-l-[3px] border-sky-700 dark:border-sky-500 ml-1">
+                  {group.events.map((event, idx) => {
+                    const startStr = format(new Date(event.start), "h:mm a");
+                    const endStr = format(new Date(event.end), "h:mm a");
+                    const locationLabel =
+                      event.restaurantId === "anteatery"
+                        ? "Anteatery"
+                        : "Brandywine";
+
+                    return (
+                      <button
+                        type="button"
+                        key={`${event.title}-${String(event.start)}-${event.restaurantId || idx}`}
+                        className="flex flex-row justify-between items-center py-2 px-3 text-left hover:bg-slate-50 dark:hover:bg-zinc-900/50 transition-colors border-b last:border-0 border-slate-100 dark:border-zinc-800 w-full"
+                        onClick={() => onSelectEvent(event)}
+                      >
+                        <div className="flex flex-col">
+                          <span className="font-medium text-slate-800 dark:text-zinc-200">
+                            {event.title}
+                          </span>
+                          <span className="text-xs text-slate-500 flex items-center mt-0.5">
+                            <LocationOnOutlinedIcon
+                              sx={{ fontSize: 14 }}
+                              className="mr-0.5"
+                            />
+                            {locationLabel}
+                          </span>
+                        </div>
+                        <div className="flex flex-col items-end text-sm text-slate-600 dark:text-zinc-400 font-medium">
+                          <span>{startStr}</span>
+                          <span>{endStr}</span>
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MobileListView;

--- a/apps/next/src/components/ui/mobile-list-view.tsx
+++ b/apps/next/src/components/ui/mobile-list-view.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
+import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
 import LocationOnOutlinedIcon from "@mui/icons-material/LocationOnOutlined";
-import { format, isSameDay, startOfDay } from "date-fns";
-import { useMemo } from "react";
+import { addMonths, format, isSameDay, startOfDay, subMonths } from "date-fns";
+import { useMemo, useState } from "react";
 import type { EventInfo } from "./card/event-card";
 
 interface MobileListViewProps {
@@ -15,11 +17,40 @@ interface MobileListViewProps {
 
 const MobileListView = ({
   currentDate,
-  onDateChange: _onDateChange,
+  onDateChange,
   filteredEvents,
   onOpenMonthPicker,
   onSelectEvent,
 }: MobileListViewProps) => {
+  const [touchStart, setTouchStart] = useState<number | null>(null);
+  const [touchEnd, setTouchEnd] = useState<number | null>(null);
+
+  // Minimum swipe distance (in px)
+  const minSwipeDistance = 50;
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    setTouchEnd(null);
+    setTouchStart(e.targetTouches[0].clientX);
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    setTouchEnd(e.targetTouches[0].clientX);
+  };
+
+  const handleTouchEnd = () => {
+    if (!touchStart || !touchEnd) return;
+    const distance = touchStart - touchEnd;
+    const isLeftSwipe = distance > minSwipeDistance;
+    const isRightSwipe = distance < -minSwipeDistance;
+
+    if (isLeftSwipe) {
+      onDateChange(addMonths(currentDate, 1));
+    }
+    if (isRightSwipe) {
+      onDateChange(subMonths(currentDate, 1));
+    }
+  };
+
   const groupedEvents = useMemo(() => {
     // Sort events just in case
     const sorted = [...filteredEvents].sort(
@@ -44,16 +75,37 @@ const MobileListView = ({
   const monthLabel = format(currentDate, "MMMM yyyy");
 
   return (
-    <div className="flex flex-col flex-1 px-4 mt-2 mb-20 overflow-y-auto">
+    <div
+      className="flex flex-col flex-1 px-4 mt-2 mb-20 overflow-y-auto"
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+    >
       {/* Scrollable Month Header */}
       <div className="sticky top-0 z-10 bg-white/95 dark:bg-zinc-950/95 backdrop-blur py-2">
-        <button
-          type="button"
-          onClick={onOpenMonthPicker}
-          className="flex items-center gap-2 px-4 py-2 bg-sky-100/50 dark:bg-sky-900/30 rounded-full text-sky-800 dark:text-sky-300 font-semibold"
-        >
-          {monthLabel} <span className="text-xs">▼</span>
-        </button>
+        <div className="bg-[#CCE1EE] dark:bg-sky-950 rounded-2xl px-4 py-4 w-full mx-auto">
+          <div className="flex items-center justify-between">
+            <button
+              type="button"
+              className="text-xl sm:text-2xl font-bold text-sky-700 dark:text-sky-400 focus:outline-none flex items-center gap-2"
+              onClick={onOpenMonthPicker}
+            >
+              {monthLabel} <span className="text-xs sm:text-sm">▼</span>
+            </button>
+            <div className="flex items-center gap-5">
+              <ArrowBackIosIcon
+                className="cursor-pointer text-slate-500 dark:text-zinc-400 focus:outline-none"
+                fontSize="small"
+                onClick={() => onDateChange(subMonths(currentDate, 1))}
+              />
+              <ArrowForwardIosIcon
+                className="cursor-pointer text-slate-500 dark:text-zinc-400 focus:outline-none"
+                fontSize="small"
+                onClick={() => onDateChange(addMonths(currentDate, 1))}
+              />
+            </div>
+          </div>
+        </div>
       </div>
 
       <div className="flex flex-col gap-6 mt-4">

--- a/apps/next/src/components/ui/mobile-list-view.tsx
+++ b/apps/next/src/components/ui/mobile-list-view.tsx
@@ -72,7 +72,7 @@ const MobileListView = ({
               >
                 {/* Date Header */}
                 <div className="flex items-center justify-between">
-                  <h3 className="font-bold text-slate-900 dark:text-zinc-100">
+                  <h3 className="font-semibold text-black dark:text-zinc-100">
                     {format(group.date, "EEEE - MMMM d, yyyy")}
                   </h3>
                   {isToday && (
@@ -100,7 +100,7 @@ const MobileListView = ({
                         onClick={() => onSelectEvent(event)}
                       >
                         <div className="flex flex-col">
-                          <span className="font-medium text-slate-800 dark:text-zinc-200">
+                          <span className="font-medium text-black dark:text-zinc-200">
                             {event.title}
                           </span>
                           <span className="text-xs text-slate-500 flex items-center mt-0.5">
@@ -111,7 +111,7 @@ const MobileListView = ({
                             {locationLabel}
                           </span>
                         </div>
-                        <div className="flex flex-col items-end text-sm text-slate-600 dark:text-zinc-400 font-medium">
+                        <div className="flex flex-col items-end text-sm text-black dark:text-zinc-400">
                           <span>{startStr}</span>
                           <span>{endStr}</span>
                         </div>

--- a/apps/next/src/components/ui/mobile-list-view.tsx
+++ b/apps/next/src/components/ui/mobile-list-view.tsx
@@ -103,7 +103,7 @@ const MobileListView = ({
                           <span className="font-medium text-black dark:text-zinc-200">
                             {event.title}
                           </span>
-                          <span className="text-xs text-slate-500 flex items-center mt-0.5">
+                          <span className="text-gray-500 flex items-center mt-0.5">
                             <LocationOnOutlinedIcon
                               sx={{ fontSize: 14 }}
                               className="mr-0.5"

--- a/apps/next/src/components/ui/mobile-list-view.tsx
+++ b/apps/next/src/components/ui/mobile-list-view.tsx
@@ -3,7 +3,7 @@
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
 import { format, isSameDay, startOfDay } from "date-fns";
-import { useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import type { EventInfo } from "./card/event-card";
 import MobileListEventRow from "./mobile-list-event-row";
 
@@ -27,11 +27,20 @@ interface MonthGroup {
 }
 
 const MobileListView = ({
+  currentDate,
   filteredEvents,
   onOpenMonthPicker,
   onSelectEvent,
 }: MobileListViewProps) => {
   const monthRefs = useRef<Record<string, HTMLDivElement | null>>({});
+
+  useEffect(() => {
+    const key = format(currentDate, "yyyy-MM");
+    monthRefs.current[key]?.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+    });
+  }, [currentDate]);
 
   const monthGroups = useMemo<MonthGroup[]>(() => {
     const sorted = [...filteredEvents].sort(

--- a/apps/next/src/components/ui/month-picker-drawer.tsx
+++ b/apps/next/src/components/ui/month-picker-drawer.tsx
@@ -3,12 +3,15 @@
 import CloseIcon from "@mui/icons-material/Close";
 import { Drawer } from "@mui/material";
 import Button from "@mui/material/Button";
+import { useMemo } from "react";
 
 interface MonthPickerDrawerProps {
   open: boolean;
   onClose: () => void;
   currentDate: Date;
   onSelectMonth: (year: number, monthIndex: number) => void;
+  /** Months that have at least one event, used to populate the picker. */
+  availableMonths: { year: number; monthIndex: number }[];
 }
 
 const MONTHS = [
@@ -31,9 +34,25 @@ const MonthPickerDrawer = ({
   onClose,
   currentDate,
   onSelectMonth,
+  availableMonths,
 }: MonthPickerDrawerProps) => {
   const currentYear = currentDate.getFullYear();
   const currentMonthIndex = currentDate.getMonth();
+
+  // Group available months by year, keep months sorted within each year.
+  const monthsByYear = useMemo(() => {
+    const byYear = new Map<number, Set<number>>();
+    for (const { year, monthIndex } of availableMonths) {
+      if (!byYear.has(year)) byYear.set(year, new Set());
+      byYear.get(year)?.add(monthIndex);
+    }
+    return Array.from(byYear.entries())
+      .map(([year, months]) => ({
+        year,
+        months: Array.from(months).sort((a, b) => a - b),
+      }))
+      .sort((a, b) => a.year - b.year);
+  }, [availableMonths]);
 
   return (
     <Drawer
@@ -53,7 +72,6 @@ const MonthPickerDrawer = ({
       }}
     >
       <div className="flex flex-col h-full bg-white dark:bg-zinc-950 p-5 rounded-t-2xl relative">
-        {/* Close Button */}
         <button
           type="button"
           onClick={onClose}
@@ -62,51 +80,42 @@ const MonthPickerDrawer = ({
           <CloseIcon fontSize="small" />
         </button>
 
-        {/* Scrollable Content */}
         <div className="flex-1 overflow-y-auto mt-2 hide-scrollbar pb-24">
-          <div className="font-bold text-xl text-sky-700 mb-4">
-            {currentYear}
-          </div>
-          <div className="grid grid-cols-3 gap-3 mb-6">
-            {MONTHS.map((monthName, index) => {
-              const isSelected = index === currentMonthIndex;
-              return (
-                <button
-                  type="button"
-                  key={`cur-${monthName}`}
-                  onClick={() => onSelectMonth(currentYear, index)}
-                  className={`py-3 px-1 rounded-lg border text-sm font-medium transition-colors ${
-                    isSelected
-                      ? "bg-sky-100 border-sky-600 text-sky-700"
-                      : "bg-white border-slate-300 text-slate-800 hover:bg-slate-50 dark:bg-zinc-900 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800"
-                  }`}
-                >
-                  {monthName}
-                </button>
-              );
-            })}
-          </div>
-
-          <div className="font-bold text-xl text-sky-700 mb-4">
-            {currentYear + 1}
-          </div>
-          <div className="grid grid-cols-3 gap-3">
-            {MONTHS.map((monthName, index) => {
-              return (
-                <button
-                  type="button"
-                  key={`next-${monthName}`}
-                  onClick={() => onSelectMonth(currentYear + 1, index)}
-                  className="py-3 px-1 rounded-lg border bg-white border-slate-300 text-slate-800 text-sm font-medium hover:bg-slate-50 transition-colors dark:bg-zinc-900 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800"
-                >
-                  {monthName}
-                </button>
-              );
-            })}
-          </div>
+          {monthsByYear.length === 0 ? (
+            <p className="text-center text-zinc-500 py-10">
+              No upcoming events.
+            </p>
+          ) : (
+            monthsByYear.map(({ year, months }) => (
+              <div key={year} className="mb-6 last:mb-0">
+                <div className="font-bold text-xl text-sky-700 mb-4">
+                  {year}
+                </div>
+                <div className="grid grid-cols-3 gap-3">
+                  {months.map((monthIndex) => {
+                    const isSelected =
+                      year === currentYear && monthIndex === currentMonthIndex;
+                    return (
+                      <button
+                        type="button"
+                        key={`${year}-${monthIndex}`}
+                        onClick={() => onSelectMonth(year, monthIndex)}
+                        className={`py-3 px-1 rounded-lg border text-sm font-medium transition-colors ${
+                          isSelected
+                            ? "bg-sky-100 border-sky-600 text-sky-700"
+                            : "bg-white border-slate-300 text-slate-800 hover:bg-slate-50 dark:bg-zinc-900 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800"
+                        }`}
+                      >
+                        {MONTHS[monthIndex]}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            ))
+          )}
         </div>
 
-        {/* Fixed Footer Buttons */}
         <div className="fixed bottom-0 left-0 w-full p-4 bg-white dark:bg-zinc-950 border-t border-slate-200 dark:border-zinc-800 flex gap-4 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)]">
           <Button
             variant="outlined"

--- a/apps/next/src/components/ui/month-picker-drawer.tsx
+++ b/apps/next/src/components/ui/month-picker-drawer.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import CloseIcon from "@mui/icons-material/Close";
+import { Drawer } from "@mui/material";
+import Button from "@mui/material/Button";
+
+interface MonthPickerDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  currentDate: Date;
+  onSelectMonth: (year: number, monthIndex: number) => void;
+}
+
+const MONTHS = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+const MonthPickerDrawer = ({
+  open,
+  onClose,
+  currentDate,
+  onSelectMonth,
+}: MonthPickerDrawerProps) => {
+  const currentYear = currentDate.getFullYear();
+  const currentMonthIndex = currentDate.getMonth();
+
+  return (
+    <Drawer
+      anchor="bottom"
+      open={open}
+      onClose={onClose}
+      sx={{
+        "& .MuiDrawer-paper": {
+          borderTopLeftRadius: "16px",
+          borderTopRightRadius: "16px",
+          height: "auto",
+          maxHeight: "90vh",
+          display: "flex",
+          flexDirection: "column",
+          bgcolor: "white",
+        },
+      }}
+    >
+      <div className="flex flex-col h-full bg-white dark:bg-zinc-950 p-5 rounded-t-2xl relative">
+        {/* Close Button */}
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-5 top-5 p-1 text-slate-800 dark:text-zinc-200"
+        >
+          <CloseIcon fontSize="small" />
+        </button>
+
+        {/* Scrollable Content */}
+        <div className="flex-1 overflow-y-auto mt-2 hide-scrollbar pb-24">
+          <div className="font-bold text-xl text-sky-700 mb-4">
+            {currentYear}
+          </div>
+          <div className="grid grid-cols-3 gap-3 mb-6">
+            {MONTHS.map((monthName, index) => {
+              const isSelected = index === currentMonthIndex;
+              return (
+                <button
+                  type="button"
+                  key={`cur-${monthName}`}
+                  onClick={() => onSelectMonth(currentYear, index)}
+                  className={`py-3 px-1 rounded-lg border text-sm font-medium transition-colors ${
+                    isSelected
+                      ? "bg-sky-100 border-sky-600 text-sky-700"
+                      : "bg-white border-slate-300 text-slate-800 hover:bg-slate-50 dark:bg-zinc-900 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800"
+                  }`}
+                >
+                  {monthName}
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="font-bold text-xl text-sky-700 mb-4">
+            {currentYear + 1}
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            {MONTHS.map((monthName, index) => {
+              return (
+                <button
+                  type="button"
+                  key={`next-${monthName}`}
+                  onClick={() => onSelectMonth(currentYear + 1, index)}
+                  className="py-3 px-1 rounded-lg border bg-white border-slate-300 text-slate-800 text-sm font-medium hover:bg-slate-50 transition-colors dark:bg-zinc-900 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800"
+                >
+                  {monthName}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Fixed Footer Buttons */}
+        <div className="fixed bottom-0 left-0 w-full p-4 bg-white dark:bg-zinc-950 border-t border-slate-200 dark:border-zinc-800 flex gap-4 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)]">
+          <Button
+            variant="outlined"
+            onClick={onClose}
+            className="flex-1 !normal-case !text-slate-800 !border-slate-300 !rounded-lg !py-3 dark:!text-zinc-200 dark:!border-zinc-700"
+          >
+            Back
+          </Button>
+          <Button
+            variant="contained"
+            onClick={onClose}
+            className="flex-1 !normal-case !bg-sky-700 !text-white !rounded-lg !py-3"
+          >
+            Jump
+          </Button>
+        </div>
+      </div>
+    </Drawer>
+  );
+};
+
+export default MonthPickerDrawer;

--- a/apps/next/src/components/ui/month-picker-drawer.tsx
+++ b/apps/next/src/components/ui/month-picker-drawer.tsx
@@ -105,24 +105,6 @@ const MonthPickerDrawer = ({
             })}
           </div>
         </div>
-
-        {/* Fixed Footer Buttons */}
-        <div className="fixed bottom-0 left-0 w-full p-4 bg-white dark:bg-zinc-950 border-t border-slate-200 dark:border-zinc-800 flex gap-4 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)]">
-          <Button
-            variant="outlined"
-            onClick={onClose}
-            className="flex-1 !normal-case !text-slate-800 !border-slate-300 !rounded-lg !py-3 dark:!text-zinc-200 dark:!border-zinc-700"
-          >
-            Back
-          </Button>
-          <Button
-            variant="contained"
-            onClick={onClose}
-            className="flex-1 !normal-case !bg-sky-700 !text-white !rounded-lg !py-3"
-          >
-            Jump
-          </Button>
-        </div>
       </div>
     </Drawer>
   );


### PR DESCRIPTION
## Summary
Mobile rewrite of the /events page that splits the single monolithic view into dedicated desktop and mobile experiences (list, calendar, and month picker). Also cleans up any types on the events page.

## Changes
- [ ] For days with multiple events the drawer is scrollable
- [ ] Figma-aligned calendar with the current day highlighted and blue dots marking days that have events
- [ ] Compact view shows scrollable, date-grouped list with sticky date headers
- [ ] Added month picker component to jump to a month of the year for navigation
- [ ] Current month of both calendar and list view pages can be scrollable hinted with angle brackets
- [ ] List view shows all events for the month

### Testing Instructions
Pull the branch and run pnpm install (the calendar view requires react-big-calendar). Go to events page on mobile and click through dates, location filters, scrollable month navigations, scrollable drawers on days with multiple events on both calendar and list views.

Closes #673 
