### PR TITLE
667/fix special schedules display bug

### DIFF
--- a/apps/next/src/components/ui/restaurant/restaurant-page.tsx
+++ b/apps/next/src/components/ui/restaurant/restaurant-page.tsx
@@ -79,7 +79,14 @@ export function RestaurantPage({
   const { data: upcomingEvents = [] } = trpc.event.upcoming.useQuery();
   const restaurantId = hall === HallEnum.ANTEATERY ? "anteatery" : "brandywine";
   const hallEvents = useMemo(
-    () => [...upcomingEvents].filter((e) => e.restaurantId === restaurantId),
+    () =>
+      [...upcomingEvents]
+        .filter((e) => e.restaurantId === restaurantId)
+        .sort(
+          (a, b) =>
+            (a.start ? new Date(a.start).getTime() : 0) -
+            (b.start ? new Date(b.start).getTime() : 0),
+        ),
     [upcomingEvents, restaurantId],
   );
 


### PR DESCRIPTION
## Summary
The Special Schedules section on dining hall pages was displaying events in whatever order the database returned them, instead of chronological order. The Events page already sorts chronologically before rendering, but the dining hall pages were only filtering events by hall, never sorting them.

## Changes
- Added a chronological sort to the hallEvents useMemo in restaurant-page.tsx, matching the same pattern already used on the Events page

### Testing Instructions
Open Brandywine or Anteatery page and view Special Schedules

## Additional Information

For the other explicit issue regarding the accordion spacing, the Figma shows schedules like a Thanksgiving schedule or Winter schedules but doesn't make it clear what information should appear inside the dropdown since right now the Special Schedules is just showing the Events. Should we be displaying the time of the event?

Addresses #667