### PR TITLE
feat: dark mode + MUI integration

### DIFF
--- a/apps/next/src/app/about/page.tsx
+++ b/apps/next/src/app/about/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Typography } from "@mui/material";
 import Image from "next/image";
 import Contributor from "@/components/ui/contributor";
 import { Button } from "@/components/ui/shadcn/button";
@@ -36,9 +37,14 @@ export default function About() {
       >
         <div className="flex flex-col" id="about-text">
           <div className="flex gap-4 items-center mb-2" id="about-header">
-            <h1 className="text-3xl font-bold" id="about-title">
+            <Typography
+              fontWeight={700}
+              color="primary"
+              id="about-title"
+              sx={{ fontSize: "1.875rem" }}
+            >
               About PeterPlate
-            </h1>
+            </Typography>
             <Image
               src="/peterplate-icon.webp"
               alt="PeterPlate's logo"
@@ -91,14 +97,16 @@ export default function About() {
             </p>
             <Dialog>
               <DialogTrigger asChild>
-                <Button className="w-fit">Privacy Policy</Button>
+                <Button className="w-fit bg-sky-700 text-white hover:bg-sky-800 dark:bg-blue-300 dark:text-gray-900 dark:hover:bg-blue-400">
+                  Privacy Policy
+                </Button>
               </DialogTrigger>
               <DialogContent className="w-md h-auto">
                 <DialogHeader>
-                  <DialogTitle className="p-4 text-center">
+                  <DialogTitle className="p-4 text-center text-sky-700 dark:text-blue-300">
                     Privacy Policy
                   </DialogTitle>
-                  <DialogDescription asChild className="p-4">
+                  <DialogDescription asChild className="p-4 dark:text-white">
                     <div>
                       <p className="mb-4">
                         PeterPlate is a cross-platform mobile application
@@ -127,9 +135,13 @@ export default function About() {
           </div>
         </div>
         <div className="flex flex-col items-center gap-4" id="contributors">
-          <h1 className="text-xl max-md:text-base max-sm:text-sm font-bold">
+          <Typography
+            fontWeight={700}
+            color="primary"
+            className="text-xl max-md:text-base max-sm:text-sm"
+          >
             Our Lovely Contributors
-          </h1>
+          </Typography>
           <div
             className="flex flex-wrap justify-center gap-2 max-w-xs"
             id="contributor-grid"
@@ -156,9 +168,13 @@ export default function About() {
                 />
               ))}
           </div>
-          <p className="text-sm italic font-light text-zinc-500">
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            className="italic font-light"
+          >
             .. you could be here!
-          </p>
+          </Typography>
         </div>
       </div>
     </div>

--- a/apps/next/src/app/events/page.tsx
+++ b/apps/next/src/app/events/page.tsx
@@ -2,9 +2,11 @@
 
 import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
 import GridOnIcon from "@mui/icons-material/GridOn";
+import { Typography } from "@mui/material";
 import Button from "@mui/material/Button";
 import { useState } from "react";
 import { trpc } from "@/utils/trpc";
+// @ts-ignore
 import "react-big-calendar/lib/css/react-big-calendar.css";
 import { addMonths, endOfMonth, startOfMonth, subMonths } from "date-fns";
 import CalendarView from "@/components/ui/calendar-view";
@@ -38,8 +40,8 @@ const Events = () => {
   });
 
   const sortedEvents =
-    events?.length > 0
-      ? [...events].sort(
+    (events?.length ?? 0) > 0
+      ? [...(events ?? [])].sort(
           (a: any, b: any) =>
             new Date(a.start).getTime() - new Date(b.start).getTime(),
         )
@@ -105,15 +107,15 @@ const Events = () => {
           id="event-scroll"
         >
           <div>
-            <h1 className="text-4xl font-bold text-sky-700 dark:text-sky-400">
+            <Typography className="text-4xl font-bold" color="primary">
               Dining Hall Events
-            </h1>
-            <p className="text-zinc-600 dark:text-zinc-400 mt-1 font-medium">
+            </Typography>
+            <Typography color="text.primary" className="mt-1 font-medium">
               Join us for special events and celebrations hosted at your local
               dining halls!
-            </p>
+            </Typography>
             <div className="flex gap-2 mt-3 items-center">
-              <span className="text-sm font-medium text-slate-900">View:</span>
+              <span className="text-sm font-medium text-slate-900 dark:text-white">View:</span>
 
               {/* Grid View Button */}
               <Button
@@ -122,8 +124,8 @@ const Events = () => {
                 size="small"
                 className={`!px-4 !py-1 flex items-center justify-center !normal-case ${
                   viewMode === "grid"
-                    ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500"
-                    : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700"
+                    ? "!bg-sky-700 !text-white !border-sky-700 hover:!bg-sky-800 dark:!bg-blue-300 dark:!text-gray-900 dark:!border-blue-300 dark:hover:!bg-blue-400"
+                    : "!bg-white !border-sky-700 !text-slate-900 hover:!bg-sky-50 dark:!bg-transparent dark:!border-blue-300 dark:!text-white dark:hover:!bg-zinc-700"
                 }`}
               >
                 <GridOnIcon className="mr-1" sx={{ fontSize: 18 }} />
@@ -137,8 +139,8 @@ const Events = () => {
                 size="small"
                 className={`!px-4 !py-1 flex items-center justify-center !normal-case ${
                   viewMode === "calendar"
-                    ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500"
-                    : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700"
+                    ? "!bg-sky-700 !text-white !border-sky-700 hover:!bg-sky-800 dark:!bg-blue-300 dark:!text-gray-900 dark:!border-blue-300 dark:hover:!bg-blue-400"
+                    : "!bg-white !border-sky-700 !text-slate-900 hover:!bg-sky-50 dark:!bg-transparent dark:!border-blue-300 dark:!text-white dark:hover:!bg-zinc-700"
                 }`}
               >
                 <CalendarTodayIcon className="mr-1" sx={{ fontSize: 18 }} />
@@ -147,9 +149,9 @@ const Events = () => {
             </div>
 
             {/* Filter Bar */}
-            <div className="flex flex-wrap gap-8 w-full bg-sky-100 dark:bg-zinc-900/50 border dark:border-zinc-800 rounded-lg p-5 pb-8 mt-4">
+            <div className="flex flex-wrap gap-8 w-full bg-[#cce1ee] dark:bg-[#434e5d] border dark:border-zinc-700 rounded-lg p-5 pb-8 mt-4">
               <div className="flex flex-col gap-3">
-                <span className="text-sm font-medium text-slate-900 dark:text-zinc-200">
+                <span className="text-sm font-medium text-slate-900 dark:text-white">
                   Event Type
                 </span>
                 <div className="flex gap-3">
@@ -159,8 +161,8 @@ const Events = () => {
                     onClick={() => setSelectedEventType("both")}
                     className={`!px-4 !py-1 flex items-center justify-center !normal-case !text-sm !font-thin ${
                       selectedEventType === "both"
-                        ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500"
-                        : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700"
+                        ? "!bg-sky-700 !text-white !border-sky-700 hover:!bg-sky-800 dark:!bg-blue-300 dark:!text-gray-900 dark:!border-blue-300 dark:hover:!bg-blue-400"
+                        : "!bg-white !border-sky-700 !text-slate-900 hover:!bg-sky-50 dark:!bg-transparent dark:!border-blue-300 dark:!text-white dark:hover:!bg-zinc-700"
                     }`}
                   >
                     All Events
@@ -171,8 +173,8 @@ const Events = () => {
                     onClick={() => setSelectedEventType("special")}
                     className={`!px-4 !py-1 flex items-center justify-center !normal-case !text-sm !font-thin ${
                       selectedEventType === "special"
-                        ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500 hover:!text-white"
-                        : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700 hover:!text-slate-900"
+                        ? "!bg-sky-700 !text-white !border-sky-700 hover:!bg-sky-800 dark:!bg-blue-300 dark:!text-gray-900 dark:!border-blue-300 dark:hover:!bg-blue-400"
+                        : "!bg-white !border-sky-700 !text-slate-900 hover:!bg-sky-50 dark:!bg-transparent dark:!border-blue-300 dark:!text-white dark:hover:!bg-zinc-700"
                     }`}
                   >
                     Special Meals
@@ -183,8 +185,8 @@ const Events = () => {
                     onClick={() => setSelectedEventType("celebration")}
                     className={`!px-4 !py-1 flex items-center justify-center !normal-case !text-sm !font-thin ${
                       selectedEventType === "celebration"
-                        ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500 hover:!text-white"
-                        : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700 hover:!text-slate-900"
+                        ? "!bg-sky-700 !text-white !border-sky-700 hover:!bg-sky-800 dark:!bg-blue-300 dark:!text-gray-900 dark:!border-blue-300 dark:hover:!bg-blue-400"
+                        : "!bg-white !border-sky-700 !text-slate-900 hover:!bg-sky-50 dark:!bg-transparent dark:!border-blue-300 dark:!text-white dark:hover:!bg-zinc-700"
                     }`}
                   >
                     Celebration
@@ -192,7 +194,7 @@ const Events = () => {
                 </div>
               </div>
               <div className="flex flex-col gap-3">
-                <span className="text-sm font-medium text-slate-900">
+                <span className="text-sm font-medium text-slate-900 dark:text-white">
                   Location
                 </span>
                 <div className="flex gap-3">
@@ -202,8 +204,8 @@ const Events = () => {
                     onClick={() => setSelectedDiningHall("both")}
                     className={`!px-4 !py-1 flex items-center justify-center !normal-case !text-sm !font-thin ${
                       selectedDiningHall === "both"
-                        ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500 hover:!text-white"
-                        : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700 hover:!text-slate-900"
+                        ? "!bg-sky-700 !text-white !border-sky-700 hover:!bg-sky-800 dark:!bg-blue-300 dark:!text-gray-900 dark:!border-blue-300 dark:hover:!bg-blue-400"
+                        : "!bg-white !border-sky-700 !text-slate-900 hover:!bg-sky-50 dark:!bg-transparent dark:!border-blue-300 dark:!text-white dark:hover:!bg-zinc-700"
                     }`}
                   >
                     All Locations
@@ -214,8 +216,8 @@ const Events = () => {
                     onClick={() => setSelectedDiningHall("brandywine")}
                     className={`!px-4 !py-1 flex items-center justify-center !normal-case !text-sm !font-thin ${
                       selectedDiningHall === "brandywine"
-                        ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500 hover:!text-white"
-                        : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700 hover:!text-slate-900"
+                        ? "!bg-sky-700 !text-white !border-sky-700 hover:!bg-sky-800 dark:!bg-blue-300 dark:!text-gray-900 dark:!border-blue-300 dark:hover:!bg-blue-400"
+                        : "!bg-white !border-sky-700 !text-slate-900 hover:!bg-sky-50 dark:!bg-transparent dark:!border-blue-300 dark:!text-white dark:hover:!bg-zinc-700"
                     }`}
                   >
                     Brandywine
@@ -226,8 +228,8 @@ const Events = () => {
                     onClick={() => setSelectedDiningHall("anteatery")}
                     className={`!px-4 !py-1 flex items-center justify-center !normal-case !text-sm !font-thin ${
                       selectedDiningHall === "anteatery"
-                        ? "!bg-sky-700 dark:!bg-sky-400 !text-white !border-sky-700 dark:!border-sky-400 hover:!bg-sky-800 dark:hover:!bg-sky-500 hover:!text-white"
-                        : "!bg-white dark:!bg-zinc-800 !border-sky-700 dark:!border-sky-400 !text-slate-900 dark:!text-zinc-100 hover:!bg-sky-50 dark:hover:!bg-zinc-700 hover:!text-slate-900"
+                        ? "!bg-sky-700 !text-white !border-sky-700 hover:!bg-sky-800 dark:!bg-blue-300 dark:!text-gray-900 dark:!border-blue-300 dark:hover:!bg-blue-400"
+                        : "!bg-white !border-sky-700 !text-slate-900 hover:!bg-sky-50 dark:!bg-transparent dark:!border-blue-300 dark:!text-white dark:hover:!bg-zinc-700"
                     }`}
                   >
                     Anteatery
@@ -253,10 +255,10 @@ const Events = () => {
           {/* GRID DISPLAY: Map over the fetched events once loaded */}
           {!isLoading && !error && viewMode === "grid" && (
             <>
-              <p className="text-sm text-zinc-700 dark:text-zinc-400">
+              <Typography variant="body2" fontWeight={600} color="text.primary">
                 Showing {filteredEvents.length} event
                 {filteredEvents.length !== 1 ? "s" : ""}
-              </p>
+              </Typography>
 
               <div className="flex sm:grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-12 overflow-x-auto sm:overflow-visible pb-2 sm:pb-0">
                 {filteredEvents.map((event: any): any => (
@@ -279,9 +281,9 @@ const Events = () => {
                 ))}
               </div>
               {filteredEvents.length === 0 && (
-                <p className="text-center text-zinc-700 py-5">
+                <Typography variant="body1" color="text.secondary" className="text-center py-5">
                   No events found :(
-                </p>
+                </Typography>
               )}
             </>
           )}

--- a/apps/next/src/app/globals.css
+++ b/apps/next/src/app/globals.css
@@ -50,6 +50,13 @@ body {
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
     --radius: 0.5rem;
+    --donut-inner: white;
+    --donut-outer: white;
+    --donut-track: #ffffff;
+    --donut-progress: #0084D1;
+    --donut-calories-value: #0369a1;
+    --donut-calories-track: #0084D1;
+    --donut-calories-progress: #00BCFF;
   }
 
   .dark {
@@ -77,6 +84,13 @@ body {
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
+    --donut-inner: #27272A;
+    --donut-outer: #31373F;
+    --donut-track: #27272A;
+    --donut-progress: var(--mui-palette-primary-main);
+    --donut-calories-value: #7CB9FF;
+    --donut-calories-track: #74D4FF;
+    --donut-calories-progress: #20336C;
   }
 }
 
@@ -178,3 +192,4 @@ body {
   background-color: #323235 !important;
   background-image: none !important;
 }
+

--- a/apps/next/src/app/globals.css
+++ b/apps/next/src/app/globals.css
@@ -57,7 +57,7 @@ body {
     --foreground: 0 0% 98%;
     --card: 240 6% 26%;
     --card-foreground: 0 0% 100%;
-    --popover: 240 10% 3.9%;
+    --popover: 240 6% 26%;
     --popover-foreground: 0 0% 98%;
     --primary: 211 100% 78%;
     --primary-foreground: 240 5.9% 10%;

--- a/apps/next/src/app/globals.css
+++ b/apps/next/src/app/globals.css
@@ -53,25 +53,25 @@ body {
   }
 
   .dark {
-    --background: 240 10% 3.9%;
+    --background: 240 4% 16%;
     --foreground: 0 0% 98%;
-    --card: 240 10% 3.9%;
-    --card-foreground: 0 0% 98%;
+    --card: 240 6% 26%;
+    --card-foreground: 0 0% 100%;
     --popover: 240 10% 3.9%;
     --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
+    --primary: 211 100% 78%;
     --primary-foreground: 240 5.9% 10%;
     --secondary: 240 3.7% 15.9%;
     --secondary-foreground: 0 0% 98%;
     --muted: 240 3.7% 15.9%;
-    --muted-foreground: 240 5% 64.9%;
+    --muted-foreground: 240 5.5% 64.3%;
     --accent: 240 3.7% 15.9%;
     --accent-foreground: 0 0% 98%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
-    --ring: 240 4.9% 83.9%;
+    --border: 240 5.9% 26.3%;
+    --input: 240 5.9% 26.3%;
+    --ring: 211 100% 78%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;

--- a/apps/next/src/app/globals.css
+++ b/apps/next/src/app/globals.css
@@ -134,3 +134,47 @@ body {
 .dark .events-calendar-wrapper .rbc-day-bg.rbc-today {
   background-color: #434e5d !important;
 }
+
+/* Date picker light mode */
+.MuiPickersDay-root {
+  color: #111827 !important;
+}
+.MuiPickersDay-root.Mui-selected {
+  background-color: #0369a1 !important;
+  color: white !important;
+}
+.MuiDayCalendar-weekDayLabel {
+  color: #111827 !important;
+}
+.MuiPickersCalendarHeader-label {
+  color: #111827 !important;
+}
+.MuiPickersArrowSwitcher-button {
+  color: #111827 !important;
+}
+
+/* Date picker dark mode */
+.dark .MuiPickersDay-root {
+  color: white !important;
+}
+.dark .MuiPickersDay-root.Mui-selected {
+  background-color: #93C5FD !important;
+  color: #111827 !important;
+}
+.dark .MuiPickersDay-today {
+  border-color: #93C5FD !important;
+}
+.dark .MuiDayCalendar-weekDayLabel {
+  color: white !important;
+}
+.dark .MuiPickersCalendarHeader-label {
+  color: white !important;
+}
+.dark .MuiPickersArrowSwitcher-button {
+  color: white !important;
+}
+/* Date picker dialog dark mode (mobile) */
+.dark .MuiDialog-paper {
+  background-color: #323235 !important;
+  background-image: none !important;
+}

--- a/apps/next/src/app/globals.css
+++ b/apps/next/src/app/globals.css
@@ -99,3 +99,38 @@ body {
     @apply bg-background text-foreground;
   }
 }
+
+/* Calendar event colors */
+.dark .events-calendar-wrapper .rbc-event {
+  background-color: #93c5fd !important;
+  color: #111827 !important;
+}
+
+.dark .events-calendar-wrapper .rbc-off-range-bg {
+  background-color: #303035 !important;
+}
+
+/* Light mode calendar borders */
+.events-calendar-wrapper .rbc-month-view,
+.events-calendar-wrapper .rbc-day-bg + .rbc-day-bg,
+.events-calendar-wrapper .rbc-month-row + .rbc-month-row,
+.events-calendar-wrapper .rbc-header {
+  border-color: #0369a1 !important;
+}
+
+/* Dark mode calendar borders */
+.dark .events-calendar-wrapper .rbc-month-view,
+.dark .events-calendar-wrapper .rbc-day-bg + .rbc-day-bg,
+.dark .events-calendar-wrapper .rbc-month-row + .rbc-month-row,
+.dark .events-calendar-wrapper .rbc-header {
+  border-color: #93c5fd !important;
+}
+
+/* Today's date highlight */
+.events-calendar-wrapper .rbc-today {
+  background-color: #cce1ee !important;
+}
+
+.dark .events-calendar-wrapper .rbc-day-bg.rbc-today {
+  background-color: #434e5d !important;
+}

--- a/apps/next/src/app/my-foods/page.tsx
+++ b/apps/next/src/app/my-foods/page.tsx
@@ -185,9 +185,7 @@ export default function MyFoodsPage() {
                     color:
                       locationFilter === loc
                         ? undefined
-                        : resolvedTheme === "dark"
-                          ? "white"
-                          : "black",
+                        : "var(--mui-palette-text-primary)",
                   }}
                   className={cn(
                     "rounded-lg px-4 py-1.5 h-8 text-sm font-medium transition whitespace-nowrap",

--- a/apps/next/src/app/my-foods/page.tsx
+++ b/apps/next/src/app/my-foods/page.tsx
@@ -1,7 +1,15 @@
 "use client";
 
-import { FormControl, InputLabel, MenuItem, Select } from "@mui/material";
+import {
+  Box,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Typography,
+} from "@mui/material";
 import type { DishInfo } from "@peterplate/api";
+import { useTheme } from "next-themes";
 import { useMemo, useState } from "react";
 import MyFoodsCard from "@/components/ui/card/my-foods-card";
 import FoodCardSkeleton from "@/components/ui/skeleton/food-card-skeleton";
@@ -45,6 +53,7 @@ export default function MyFoodsPage() {
   const [searchQuery, setSearchQuery] = useState("");
   const [sortOption, setSortOption] = useState<SortOption>("recent");
   const [showMobileSort, setShowMobileSort] = useState(false);
+  const { resolvedTheme } = useTheme();
 
   const {
     favorites,
@@ -138,36 +147,53 @@ export default function MyFoodsPage() {
   const hasError = !!favoritesError || !!ratedError;
 
   return (
-    <div
+    <Box
       className={`mx-auto flex max-w-7xl flex-col gap-4 px-4 pb-8 ${isDesktop ? "pt-20" : ""} sm:px-6 lg:px-8`}
+      sx={{ bgcolor: "background.default", minHeight: "100vh" }}
     >
       {/* Header */}
       <header className="space-y-1">
-        <h1 className="text-4xl text-sky-700 font-bold mb-4">My Foods</h1>
-        <p className="hidden text-sm md:block">
+        <Typography color="primary" fontWeight={700} className="text-4xl mb-4">
+          My Foods
+        </Typography>
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          className="hidden md:block"
+        >
           View all the dishes you have favorited or rated across UCI dining
           halls!
-        </p>
+        </Typography>
       </header>
 
       {/* Filter bar */}
       {isDesktop ? (
         /* ── Desktop: single row ── */
-        <div className="flex flex-row flex-wrap items-center gap-4 rounded-2xl bg-sky-100 p-4">
+        <div className="flex flex-row flex-wrap items-center gap-4 rounded-2xl bg-sky-100 dark:bg-[#434e5d] p-4">
           {/* Location */}
           <div className="flex flex-col gap-1.5 flex-shrink-0">
-            <span className="text-sm font-medium">Location</span>
+            <Typography variant="body2" fontWeight={500} color="text.primary">
+              Location
+            </Typography>
             <div className="flex flex-row gap-2">
               {(Object.keys(LOCATION_LABELS) as LocationFilter[]).map((loc) => (
                 <button
                   key={loc}
                   type="button"
                   onClick={() => setLocationFilter(loc)}
+                  style={{
+                    color:
+                      locationFilter === loc
+                        ? undefined
+                        : resolvedTheme === "dark"
+                          ? "white"
+                          : "black",
+                  }}
                   className={cn(
                     "rounded-lg px-4 py-1.5 h-8 text-sm font-medium transition whitespace-nowrap",
                     locationFilter === loc
-                      ? "bg-sky-700 text-white shadow-sm"
-                      : "bg-white border border-sky-700 hover:bg-zinc-100",
+                      ? "bg-sky-700 dark:bg-blue-300 text-white dark:text-gray-900 shadow-sm"
+                      : "bg-white dark:bg-transparent border border-sky-700 dark:border-blue-300 hover:bg-zinc-100 dark:hover:bg-blue-300/10",
                   )}
                 >
                   {LOCATION_LABELS[loc]}
@@ -180,7 +206,7 @@ export default function MyFoodsPage() {
             {/* Search */}
             <div className="relative w-64">
               <svg
-                className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 pointer-events-none"
+                className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 dark:text-zinc-400 pointer-events-none"
                 fill="none"
                 stroke="currentColor"
                 strokeWidth={2}
@@ -195,7 +221,7 @@ export default function MyFoodsPage() {
                 placeholder="Search meals..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full pl-9 pr-4 py-2 text-sm rounded-xl border border-sky-700 bg-white focus:ring-2 focus:ring-sky-700 focus:outline-none"
+                className="w-full pl-9 pr-4 py-2 text-sm rounded-xl border border-sky-700 dark:border-blue-300 !bg-white dark:!bg-[#323235] dark:!text-white focus:ring-2 focus:ring-sky-700 dark:focus:ring-blue-300 focus:outline-none"
               />
             </div>
 
@@ -209,7 +235,7 @@ export default function MyFoodsPage() {
                 <InputLabel
                   id="sort-label"
                   shrink
-                  className="!text-sky-700 !text-sm !font-semibold [&.Mui-focused]:!text-sky-700"
+                  className="!text-sky-700 dark:!text-blue-300 !text-sm !font-semibold [&.Mui-focused]:!text-sky-700 dark:[&.Mui-focused]:!text-blue-300"
                 >
                   Filter by
                 </InputLabel>
@@ -217,7 +243,32 @@ export default function MyFoodsPage() {
                   value={sortOption}
                   onChange={(e) => setSortOption(e.target.value as SortOption)}
                   label="Filter by"
-                  className="!h-9 !text-sm !rounded-xl !bg-white [&_.MuiOutlinedInput-notchedOutline]:!border-sky-700 [&:hover_.MuiOutlinedInput-notchedOutline]:!border-sky-700 [&.Mui-focused_.MuiOutlinedInput-notchedOutline]:!border-sky-700 [&_.MuiSelect-select]:!py-1.5"
+                  MenuProps={{
+                    PaperProps: {
+                      sx: {
+                        bgcolor:
+                          resolvedTheme === "dark" ? "#323235" : undefined,
+                        backgroundImage: "none",
+                        "& .MuiMenuItem-root": {
+                          color: resolvedTheme === "dark" ? "white" : undefined,
+                        },
+                        "& .MuiMenuItem-root:hover": {
+                          bgcolor:
+                            resolvedTheme === "dark" ? "#434e5d" : undefined,
+                        },
+                        "& .MuiMenuItem-root.Mui-selected": {
+                          bgcolor:
+                            resolvedTheme === "dark" ? "#93C5FD" : "#0369a1",
+                          color: resolvedTheme === "dark" ? "#111827" : "white",
+                        },
+                        "& .MuiMenuItem-root.Mui-selected:hover": {
+                          bgcolor:
+                            resolvedTheme === "dark" ? "#93C5FD" : "#0369a1",
+                        },
+                      },
+                    },
+                  }}
+                  className="!h-9 !text-sm !rounded-xl !bg-white dark:!bg-[#323235] dark:!text-white [&_.MuiOutlinedInput-notchedOutline]:!border-sky-700 dark:[&_.MuiOutlinedInput-notchedOutline]:!border-blue-300 [&:hover_.MuiOutlinedInput-notchedOutline]:!border-sky-700 dark:[&:hover_.MuiOutlinedInput-notchedOutline]:!border-blue-300 [&.Mui-focused_.MuiOutlinedInput-notchedOutline]:!border-sky-700 dark:[&.Mui-focused_.MuiOutlinedInput-notchedOutline]:!border-blue-300 [&_.MuiSelect-select]:!py-1.5"
                 >
                   {SORT_OPTIONS.map(({ value, label }) => (
                     <MenuItem key={value} value={value}>
@@ -231,7 +282,7 @@ export default function MyFoodsPage() {
         </div>
       ) : (
         /* ── Mobile: stacked layout ── */
-        <div className="flex flex-col gap-3 rounded-2xl bg-sky-100 p-4">
+        <div className="flex flex-col gap-3 rounded-2xl bg-sky-100 dark:bg-[#434e5d] p-4">
           {/* Location buttons — no label */}
           <div className="flex flex-row gap-2">
             {(Object.keys(LOCATION_LABELS) as LocationFilter[]).map((loc) => (
@@ -242,8 +293,8 @@ export default function MyFoodsPage() {
                 className={cn(
                   "rounded-lg px-2 py-1.5 h-8 text-sm font-medium transition whitespace-nowrap flex-1 min-w-0 truncate",
                   locationFilter === loc
-                    ? "bg-sky-700 text-white shadow-sm"
-                    : "bg-white border border-sky-700 hover:bg-zinc-100",
+                    ? "bg-sky-700 dark:bg-blue-300 text-white dark:text-gray-900 shadow-sm"
+                    : "bg-white dark:bg-transparent border border-sky-700 dark:border-blue-300 hover:bg-zinc-100 dark:hover:bg-blue-300/10",
                 )}
               >
                 {LOCATION_LABELS[loc]}
@@ -255,7 +306,7 @@ export default function MyFoodsPage() {
           <div className="flex flex-row gap-2 items-center">
             <div className="relative flex-1">
               <svg
-                className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 pointer-events-none"
+                className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 dark:text-zinc-400 pointer-events-none"
                 fill="none"
                 stroke="currentColor"
                 strokeWidth={2}
@@ -270,7 +321,7 @@ export default function MyFoodsPage() {
                 placeholder="Search meals..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full pl-9 pr-4 py-2 text-sm rounded-xl border border-sky-700 bg-white focus:ring-2 focus:ring-sky-700 focus:outline-none"
+                className="w-full pl-9 pr-4 py-2 text-sm rounded-xl border border-sky-700 dark:border-blue-300 !bg-white dark:!bg-[#323235] dark:!text-white focus:ring-2 focus:ring-sky-700 dark:focus:ring-blue-300 focus:outline-none"
               />
             </div>
 
@@ -282,8 +333,8 @@ export default function MyFoodsPage() {
               className={cn(
                 "flex-shrink-0 flex items-center justify-center w-9 h-9 rounded-xl border transition",
                 showMobileSort
-                  ? "bg-sky-700 border-sky-700 text-white"
-                  : "bg-white border-sky-700 text-sky-700 hover:bg-sky-50",
+                  ? "bg-sky-700 dark:bg-blue-300 border-sky-700 dark:border-blue-300 text-white dark:text-gray-900"
+                  : "bg-white dark:bg-transparent border-sky-700 dark:border-blue-300 hover:bg-sky-50 dark:hover:bg-blue-300/10",
               )}
             >
               {/* Filter / funnel icon */}
@@ -312,11 +363,19 @@ export default function MyFoodsPage() {
                   key={value}
                   type="button"
                   onClick={() => setSortOption(value)}
+                  style={{
+                    color:
+                      sortOption === value
+                        ? undefined
+                        : resolvedTheme === "dark"
+                          ? "white"
+                          : "black",
+                  }}
                   className={cn(
                     "rounded-lg px-3 py-1.5 text-xs font-medium transition whitespace-nowrap border",
                     sortOption === value
-                      ? "bg-sky-700 text-white border-sky-700 shadow-sm"
-                      : "bg-white border-sky-700 text-sky-700 hover:bg-sky-50",
+                      ? "bg-sky-700 dark:bg-blue-300 text-white dark:text-gray-900 border-sky-700 dark:border-blue-300 shadow-sm"
+                      : "bg-white dark:bg-transparent border-sky-700 dark:border-blue-300 hover:bg-sky-50 dark:hover:bg-blue-300/10",
                   )}
                 >
                   {label}
@@ -346,21 +405,24 @@ export default function MyFoodsPage() {
       {/* Content */}
       {!isLoading && !hasError && (
         <>
-          <p className="text-sm">
+          <Typography variant="body2" color="text.primary">
             Showing <span>{filteredEntries.length}</span>{" "}
             {filteredEntries.length === 1 ? "dish" : "dishes"}
-          </p>
+          </Typography>
 
           {filteredEntries.length === 0 ? (
-            <div className="rounded-2xl border border-dashed border-zinc-200 bg-white/60 px-6 py-16 text-center shadow-sm">
-              <p className="text-lg font-medium text-zinc-800">
+            <div className="rounded-2xl border border-dashed border-zinc-200 dark:border-zinc-600 bg-white/60 dark:bg-[#323235] px-6 py-16 text-center shadow-sm">
+              <Typography variant="body1" fontWeight={500} color="text.primary">
                 No dishes found
-              </p>
-              <p className="mt-2 text-sm text-zinc-500">
+              </Typography>
+              <Typography
+                variant="body2"
+                className="mt-2 text-zinc-500 dark:text-zinc-400"
+              >
                 {mergedEntries.length === 0
                   ? "You haven't favorited or rated any meals yet. Browse the menus to get started!"
                   : "No dishes match your current filters. Try adjusting your search or location."}
-              </p>
+              </Typography>
             </div>
           ) : (
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-10">
@@ -378,6 +440,6 @@ export default function MyFoodsPage() {
           )}
         </>
       )}
-    </div>
+    </Box>
   );
 }

--- a/apps/next/src/app/nutrition/page.tsx
+++ b/apps/next/src/app/nutrition/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import SearchMealCard from "@/components/ui/card/search-meal-card";
@@ -211,9 +213,17 @@ export default function MealTracker() {
   if (error) return <div>Error loading meals</div>;
 
   return (
-    <div className="min-h-screen p-2 md:p-8 mt-2 md:mt-12">
+    <Box
+      sx={{ bgcolor: "background.default", minHeight: "100vh" }}
+      className="p-2 md:p-8 mt-2 md:mt-12"
+    >
       <div className="px-2 md:px-8">
-        <h1 className="text-2xl md:text-3xl font-bold text-sky-700 dark:text-sky-400 flex items-center justify-between">
+        <Typography
+          variant="h5"
+          fontWeight={700}
+          color="primary"
+          className="text-2xl md:text-3xl flex items-center justify-between"
+        >
           <span className="flex items-center gap-2 flex-nowrap whitespace-nowrap">
             Tracker
             {selectedDay && (
@@ -240,14 +250,14 @@ export default function MealTracker() {
               />
             )}
           </div>
-        </h1>
+        </Typography>
 
         {/* Subheading + History - desktop only */}
         <div className="hidden md:flex items-center justify-between mt-1">
-          <p className="text-zinc-800 dark:text-zinc-400">
-            Keep track of your health using our Nutrition Tracker! Add dishes to
+          <Typography variant="body1" color="text.primary">
+            Keep track of your eating using our Nutrition Tracker! Add dishes to
             count them towards your totals!
-          </p>
+          </Typography>
           {userId && (
             <TrackerHistory
               onDateSelect={() => {}}
@@ -362,11 +372,13 @@ export default function MealTracker() {
 
         {/* Counted Foods */}
         <div className="mt-6">
-          <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+          <Typography variant="h6" fontWeight={600} color="text.primary">
             Counted Foods
-          </h2>
+          </Typography>
           {countedMeals.length === 0 ? (
-            <p className="mt-2 text-sm text-zinc-500">No counted foods.</p>
+            <Typography variant="body2" color="text.secondary" className="mt-2">
+              No counted foods.
+            </Typography>
           ) : (
             <div className="flex flex-wrap gap-4 mt-4">
               {countedMeals.map((meal) => (
@@ -388,14 +400,18 @@ export default function MealTracker() {
 
         {/* Suggested Foods */}
         <div className="mt-6">
-          <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+          <Typography variant="h6" fontWeight={600} color="text.primary">
             Suggested Foods
-          </h2>
+          </Typography>
           <div className="flex flex-wrap gap-4 mt-4">
             {suggestedMeals.length === 0 ? (
-              <p className="mt-2 text-zinc-500 text-sm">
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                className="mt-2"
+              >
                 Dishes from the past week logged 5+ times will appear here.
-              </p>
+              </Typography>
             ) : (
               suggestedMeals.map((meal) => (
                 <SearchMealCard
@@ -432,6 +448,6 @@ export default function MealTracker() {
           })
         }
       />
-    </div>
+    </Box>
   );
 }

--- a/apps/next/src/app/page.tsx
+++ b/apps/next/src/app/page.tsx
@@ -7,6 +7,7 @@ import {
   LocationOn,
   Star,
 } from "@mui/icons-material";
+import { Box, Typography } from "@mui/material";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -72,19 +73,24 @@ function DesktopHome(): React.JSX.Element {
   const popularDishes = getPopularDishes(allDishes, 5);
 
   return (
-    <div className="min-h-screen bg-white dark:bg-neutral-950">
+    <Box sx={{ minHeight: "100vh", bgcolor: "background.default" }}>
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-8 mt-14">
-        <h1 className="text-2xl sm:text-3xl font-bold text-neutral-900 dark:text-neutral-100">
+        <Typography className="text-2xl sm:text-3xl font-bold" gutterBottom>
           See what's on the menu today!
-        </h1>
+        </Typography>
 
         {/* ── Dining Halls ── */}
         <section>
-          <h2 className="text-2xl font-bold text-sky-700 mb-4">Dining Halls</h2>
+          <Typography className="text-2xl font-bold mb-4" color="primary">
+            Dining Halls
+          </Typography>
           <div className="grid grid-cols-2 gap-12">
             {/* Brandywine Card */}
             <Link href="/brandywine" className="group">
-              <div className="rounded-xl overflow-hidden border border-neutral-200 dark:border-neutral-700 shadow-sm hover:shadow-md transition">
+              <Box
+                className="rounded-xl overflow-hidden shadow-sm hover:shadow-md transition"
+                sx={{ border: 1, borderColor: "divider" }}
+              >
                 <div className="relative w-full h-56">
                   <Image
                     src="/brandywine.webp"
@@ -96,30 +102,38 @@ function DesktopHome(): React.JSX.Element {
                 </div>
                 <div className="flex items-center justify-between p-4">
                   <div className="space-y-1.5">
-                    <h3 className="text-lg font-semibold text-sky-700">
+                    <Typography
+                      className="text-lg font-semibold"
+                      color="primary"
+                    >
                       Brandywine
-                    </h3>
-                    <div className="flex items-center gap-1.5 text-sm text-neutral-500 dark:text-neutral-400">
-                      <LocationOn className="w-4 h-4" />
-                      <span>Middle Earth Community</span>
-                    </div>
-                    <div className="flex items-center gap-1.5 text-sm text-neutral-500 dark:text-neutral-400">
-                      <AccessTime className="w-4 h-4" />
-                      <span>
+                    </Typography>
+                    <Box className="flex items-center gap-1.5">
+                      <LocationOn fontSize="small" />
+                      <Typography variant="body2" color="text.secondary">
+                        Middle Earth Community
+                      </Typography>
+                    </Box>
+                    <Box className="flex items-center gap-1.5">
+                      <AccessTime fontSize="small" />
+                      <Typography variant="body2" color="text.secondary">
                         {isLoading
                           ? "Loading..."
                           : brandywineStatus.statusText || "Hours unavailable"}
-                      </span>
-                    </div>
+                      </Typography>
+                    </Box>
                   </div>
-                  <ChevronRight className="text-sky-700 w-6 h-6" />
+                  <ChevronRight color="primary" className="w-6 h-6" />
                 </div>
-              </div>
+              </Box>
             </Link>
 
             {/* Anteatery Card */}
             <Link href="/anteatery" className="group">
-              <div className="rounded-xl overflow-hidden border border-neutral-200 dark:border-neutral-700 shadow-sm hover:shadow-md transition">
+              <Box
+                className="rounded-xl overflow-hidden shadow-sm hover:shadow-md transition"
+                sx={{ border: 1, borderColor: "divider" }}
+              >
                 <div className="relative w-full h-56">
                   <Image
                     src="/anteatery.webp"
@@ -131,45 +145,53 @@ function DesktopHome(): React.JSX.Element {
                 </div>
                 <div className="flex items-center justify-between p-4">
                   <div className="space-y-1.5">
-                    <h3 className="text-lg font-semibold text-sky-700">
+                    <Typography
+                      className="text-lg font-semibold"
+                      color="primary"
+                    >
                       Anteatery
-                    </h3>
-                    <div className="flex items-center gap-1.5 text-sm text-neutral-500 dark:text-neutral-400">
-                      <LocationOn className="w-4 h-4" />
-                      <span>Mesa Court</span>
-                    </div>
-                    <div className="flex items-center gap-1.5 text-sm text-neutral-500 dark:text-neutral-400">
-                      <AccessTime className="w-4 h-4" />
-                      <span>
+                    </Typography>
+                    <Box className="flex items-center gap-1.5">
+                      <LocationOn fontSize="small" />
+                      <Typography variant="body2" color="text.secondary">
+                        Mesa Court
+                      </Typography>
+                    </Box>
+                    <Box className="flex items-center gap-1.5">
+                      <AccessTime fontSize="small" />
+                      <Typography variant="body2" color="text.secondary">
                         {isLoading
                           ? "Loading..."
                           : anteateryStatus.statusText || "Hours unavailable"}
-                      </span>
-                    </div>
+                      </Typography>
+                    </Box>
                   </div>
-                  <ChevronRight className="text-sky-700 w-6 h-6" />
+                  <ChevronRight color="primary" className="w-6 h-6" />
                 </div>
-              </div>
+              </Box>
             </Link>
           </div>
         </section>
 
         {/* ── Popular Today ── */}
         <section>
-          <h2 className="text-xl font-bold text-sky-700 dark:text-neutral-100 mb-4">
+          <Typography className="text-xl font-bold mb-4" color="primary">
             Popular Today
-          </h2>
+          </Typography>
           {isLoading ? (
             <div className="flex gap-4 overflow-x-auto pb-2">
               {["s1", "s2", "s3", "s4", "s5"].map((key) => (
-                <div
+                <Box
                   key={key}
-                  className="flex-shrink-0 w-44 h-52 rounded-xl bg-neutral-100 dark:bg-neutral-800 animate-pulse"
+                  className="flex-shrink-0 w-44 h-52 rounded-xl animate-pulse"
+                  sx={{ bgcolor: "background.paper" }}
                 />
               ))}
             </div>
           ) : popularDishes.length === 0 ? (
-            <p className="text-neutral-500">No dishes available today.</p>
+            <Typography color="text.secondary">
+              No dishes available today.
+            </Typography>
           ) : (
             <div className="grid grid-cols-5 gap-4">
               {popularDishes.map((dish, idx) => (
@@ -187,18 +209,18 @@ function DesktopHome(): React.JSX.Element {
         {/* ── Upcoming Events ── */}
         <section>
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-xl font-bold text-sky-700 dark:text-neutral-100">
+            <Typography className="text-xl font-bold" color="primary">
               Upcoming Events
-            </h2>
-            <Link
-              href="/events"
-              className="text-sm font-medium text-sky-700 flex items-center gap-1"
-            >
-              See More <ChevronRight className="w-4 h-4" />
+            </Typography>
+            <Link href="/events" className="flex items-center gap-1">
+              <Typography variant="body2" color="primary">
+                See More
+              </Typography>
+              <ChevronRight color="primary" className="w-4 h-4" />
             </Link>
           </div>
           {!events || events.length === 0 ? (
-            <p className="text-neutral-500">No upcoming events.</p>
+            <Typography color="text.secondary">No upcoming events.</Typography>
           ) : (
             <div className="grid grid-cols-4 gap-4">
               {sortedEvents(events, 4).map((event, idx) => (
@@ -211,7 +233,7 @@ function DesktopHome(): React.JSX.Element {
           )}
         </section>
       </div>
-    </div>
+    </Box>
   );
 }
 
@@ -243,15 +265,20 @@ function MobileHome(): React.JSX.Element {
   const popularDishes = getPopularDishes(allDishes, 3);
 
   return (
-    <div className="min-h-screen bg-white dark:bg-neutral-950">
+    <Box sx={{ minHeight: "100vh", bgcolor: "background.default" }}>
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-3">
         {/* ── Dining Halls ── */}
         <section>
-          <h2 className="text-1xl font-bold text-sky-700 mb-2">Dining Halls</h2>
+          <Typography className="text-1xl font-bold mb-2" color="primary">
+            Dining Halls
+          </Typography>
           <div className="space-y-3">
             {/* Brandywine Card */}
             <Link href="/brandywine" className="group block">
-              <div className="rounded-xl overflow-hidden border border-neutral-200 dark:border-neutral-700 shadow-sm hover:shadow-md transition">
+              <Box
+                className="rounded-xl overflow-hidden shadow-sm hover:shadow-md transition"
+                sx={{ border: 1, borderColor: "divider" }}
+              >
                 <div className="relative w-full h-24">
                   <Image
                     src="/brandywine.webp"
@@ -263,33 +290,42 @@ function MobileHome(): React.JSX.Element {
                 </div>
                 <div className="relative flex items-center justify-between p-3">
                   <div className="space-y-1">
-                    <h3 className="text-sm font-semibold text-sky-700">
+                    <Typography
+                      className="text-sm font-semibold"
+                      color="primary"
+                    >
                       Brandywine
-                    </h3>
-                    <div className="flex items-center gap-1.5 text-xs text-neutral-500 dark:text-neutral-400">
+                    </Typography>
+                    <Box className="flex items-center gap-1.5">
                       <LocationOn style={{ fontSize: 16 }} />
-                      <span>Middle Earth Community</span>
-                    </div>
-                    <div className="flex items-center gap-1.5 text-xs text-neutral-500 dark:text-neutral-400">
+                      <Typography variant="body2" color="text.secondary">
+                        Middle Earth Community
+                      </Typography>
+                    </Box>
+                    <Box className="flex items-center gap-1.5">
                       <AccessTime style={{ fontSize: 16 }} />
-                      <span>
+                      <Typography variant="body2" color="text.secondary">
                         {isLoading
                           ? "Loading..."
                           : brandywineStatus.statusText || "Hours unavailable"}
-                      </span>
-                    </div>
+                      </Typography>
+                    </Box>
                   </div>
                   <ChevronRight
-                    className="absolute top-3 right-3 text-sky-700"
+                    color="primary"
+                    className="absolute top-3 right-3"
                     style={{ fontSize: 16 }}
                   />
                 </div>
-              </div>
+              </Box>
             </Link>
 
             {/* Anteatery Card */}
             <Link href="/anteatery" className="group block">
-              <div className="rounded-xl overflow-hidden border border-neutral-200 dark:border-neutral-700 shadow-sm hover:shadow-md transition">
+              <Box
+                className="rounded-xl overflow-hidden shadow-sm hover:shadow-md transition"
+                sx={{ border: 1, borderColor: "divider" }}
+              >
                 <div className="relative w-full h-24">
                   <Image
                     src="/anteatery.webp"
@@ -301,51 +337,61 @@ function MobileHome(): React.JSX.Element {
                 </div>
                 <div className="relative flex items-center justify-between p-3">
                   <div className="space-y-1">
-                    <h3 className="text-sm font-semibold text-sky-700">
+                    <Typography
+                      className="text-sm font-semibold"
+                      color="primary"
+                    >
                       Anteatery
-                    </h3>
-                    <div className="flex items-center gap-1.5 text-xs text-neutral-500 dark:text-neutral-400">
+                    </Typography>
+                    <Box className="flex items-center gap-1.5">
                       <LocationOn style={{ fontSize: 16 }} />
-                      <span>Mesa Court</span>
-                    </div>
-                    <div className="flex items-center gap-1.5 text-xs text-neutral-500 dark:text-neutral-400">
+                      <Typography variant="body2" color="text.secondary">
+                        Mesa Court
+                      </Typography>
+                    </Box>
+                    <Box className="flex items-center gap-1.5">
                       <AccessTime style={{ fontSize: 16 }} />
-                      <span>
+                      <Typography variant="body2" color="text.secondary">
                         {isLoading
                           ? "Loading..."
                           : anteateryStatus.statusText || "Hours unavailable"}
-                      </span>
-                    </div>
+                      </Typography>
+                    </Box>
                   </div>
                   <ChevronRight
-                    className="absolute top-3 right-3 text-sky-700"
+                    color="primary"
+                    className="absolute top-3 right-3"
                     style={{ fontSize: 16 }}
                   />
                 </div>
-              </div>
+              </Box>
             </Link>
           </div>
         </section>
 
         {/* Popular Today */}
         <section>
-          <h2 className="text-1xl sm:text-3xl font-bold text-sky-700 dark:text-neutral-100 mb-4">
+          <Typography
+            className="text-1xl sm:text-3xl font-bold"
+            color="primary"
+          >
             Popular Today
-          </h2>
+          </Typography>
 
           {isLoading ? (
             <div className="flex gap-4 overflow-x-auto pb-2">
               {["s1", "s2", "s3", "s4", "s5"].map((key) => (
-                <div
+                <Box
                   key={key}
-                  className="flex-shrink-0 w-44 h-52 rounded-xl bg-neutral-100 dark:bg-neutral-800 animate-pulse"
+                  className="flex-shrink-0 w-44 h-52 rounded-xl animate-pulse"
+                  sx={{ bgcolor: "background.paper" }}
                 />
               ))}
             </div>
           ) : popularDishes.length === 0 ? (
-            <p className="text-sm text-neutral-500">
+            <Typography variant="body2" color="text.secondary">
               No dishes available today.
-            </p>
+            </Typography>
           ) : (
             <div className="flex gap-3 overflow-x-auto pb-2 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
               {popularDishes.map((dish, idx) => (
@@ -364,19 +410,23 @@ function MobileHome(): React.JSX.Element {
         {/* Upcoming Events */}
         <section>
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-1xl sm:text-3xl font-bold text-sky-700 dark:text-neutral-100">
-              Upcoming Events
-            </h2>
-            <Link
-              href="/events"
-              className="text-sm font-medium text-sky-700 hover:text-sky-700 flex items-center gap-1"
+            <Typography
+              className="text-1xl sm:text-3xl font-bold"
+              color="primary"
             >
-              See More{" "}
-              <ChevronRight className="text-sky-700" style={{ fontSize: 16 }} />
+              Upcoming Events
+            </Typography>
+            <Link href="/events" className="flex items-center gap-1">
+              <Typography variant="body2" color="primary">
+                See More
+              </Typography>
+              <ChevronRight color="primary" style={{ fontSize: 16 }} />
             </Link>
           </div>
           {!events || events.length === 0 ? (
-            <p className="text-sm text-neutral-500">No upcoming events.</p>
+            <Typography variant="body2" color="text.secondary">
+              No upcoming events.
+            </Typography>
           ) : (
             <div className="flex gap-3 overflow-x-auto pb-2 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
               {sortedEvents(events, 3).map((event, idx) => (
@@ -390,6 +440,6 @@ function MobileHome(): React.JSX.Element {
           )}
         </section>
       </div>
-    </div>
+    </Box>
   );
 }

--- a/apps/next/src/app/page.tsx
+++ b/apps/next/src/app/page.tsx
@@ -88,7 +88,7 @@ function DesktopHome(): React.JSX.Element {
             {/* Brandywine Card */}
             <Link href="/brandywine" className="group">
               <Box
-                className="rounded-xl overflow-hidden shadow-sm hover:shadow-md transition"
+                className="rounded-xl overflow-hidden shadow-sm hover:shadow-md transition dark:bg-[#323235]"
                 sx={{ border: 1, borderColor: "divider" }}
               >
                 <div className="relative w-full h-56">
@@ -131,7 +131,7 @@ function DesktopHome(): React.JSX.Element {
             {/* Anteatery Card */}
             <Link href="/anteatery" className="group">
               <Box
-                className="rounded-xl overflow-hidden shadow-sm hover:shadow-md transition"
+                className="rounded-xl overflow-hidden shadow-sm hover:shadow-md transition dark:bg-[#323235]"
                 sx={{ border: 1, borderColor: "divider" }}
               >
                 <div className="relative w-full h-56">
@@ -276,7 +276,7 @@ function MobileHome(): React.JSX.Element {
             {/* Brandywine Card */}
             <Link href="/brandywine" className="group block">
               <Box
-                className="rounded-xl overflow-hidden shadow-sm hover:shadow-md transition"
+                className="rounded-xl overflow-hidden shadow-sm hover:shadow-md transition dark:bg-[#323235]"
                 sx={{ border: 1, borderColor: "divider" }}
               >
                 <div className="relative w-full h-24">
@@ -323,7 +323,7 @@ function MobileHome(): React.JSX.Element {
             {/* Anteatery Card */}
             <Link href="/anteatery" className="group block">
               <Box
-                className="rounded-xl overflow-hidden shadow-sm hover:shadow-md transition"
+                className="rounded-xl overflow-hidden shadow-sm hover:shadow-md transition dark:bg-[#323235]"
                 sx={{ border: 1, borderColor: "divider" }}
               >
                 <div className="relative w-full h-24">

--- a/apps/next/src/app/ratings/page.tsx
+++ b/apps/next/src/app/ratings/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Typography } from "@mui/material";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
@@ -56,7 +57,15 @@ export default function RatedFoods() {
         >
           <MealDivider title="My Rated Foods" />
 
-          {isLoading && <p className="text-center">Loading your ratings...</p>}
+          {isLoading && (
+            <Typography
+              variant="body1"
+              color="text.secondary"
+              className="text-center"
+            >
+              Loading your ratings...
+            </Typography>
+          )}
 
           {error && (
             <p className="text-red-500 w-full text-center">
@@ -71,9 +80,13 @@ export default function RatedFoods() {
                 <RatingsCard key={`${food.id}|${food.ratedAt}`} food={food} />
               ))
             ) : (
-              <p className="text-center text-zinc-700 py-5">
+              <Typography
+                variant="body1"
+                color="text.secondary"
+                className="text-center py-5"
+              >
                 You haven't rated any foods yet
-              </p>
+              </Typography>
             ))}
           {!isLoading &&
             !error &&

--- a/apps/next/src/components/auth/google-sign-in.tsx
+++ b/apps/next/src/components/auth/google-sign-in.tsx
@@ -22,7 +22,10 @@ export function GoogleSignInButton() {
   };
 
   return (
-    <Button onClick={handleSignIn} className="w-full">
+    <Button
+      onClick={handleSignIn}
+      className="w-full bg-sky-700 text-white hover:bg-sky-800 dark:bg-blue-300 dark:text-gray-900 dark:hover:bg-blue-400"
+    >
       Sign In with Google
     </Button>
   );

--- a/apps/next/src/components/ingredients-dialog.tsx
+++ b/apps/next/src/components/ingredients-dialog.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog } from "@mui/material";
+import { Button, Dialog, Typography } from "@mui/material";
 import { useState } from "react";
 
 interface IngredientsDialogProps {
@@ -34,13 +34,22 @@ export default function IngredientsDialog({
         Show All Ingredients
       </Button>
       <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-        <div className="grid gap-2 pb-6">
-          <h2 className="text-lg font-semibold leading-none tracking-tight px-5 pt-6">
+        <div className="grid gap-2 pb-6 dark:bg-[#303035]">
+          <Typography
+            variant="h6"
+            fontWeight={600}
+            color="primary"
+            className="px-5 pt-6"
+          >
             {name} Ingredients
-          </h2>
-          <p className="px-5 text-sm max-h-48 overflow-y-scroll">
+          </Typography>
+          <Typography
+            variant="body2"
+            color="text.primary"
+            className="px-5 max-h-48 overflow-y-scroll"
+          >
             {ingredients}
-          </p>
+          </Typography>
         </div>
       </Dialog>
     </>

--- a/apps/next/src/components/progress-donut.tsx
+++ b/apps/next/src/components/progress-donut.tsx
@@ -24,14 +24,16 @@ interface Props {
    */
   trackColor?: string;
   progressColor?: string;
+  valueColor?: string;
 }
 
 export function ProgressDonut({
   progress_value,
   max_value,
   display_unit,
-  trackColor = "#ffffff",
-  progressColor = "#0084D1",
+  trackColor = "var(--donut-track)",
+  progressColor = "var(--donut-progress)",
+  valueColor,
 }: Props) {
   const value = Math.max(0, Math.min(progress_value, max_value));
   const percent = value / max_value;
@@ -43,9 +45,21 @@ export function ProgressDonut({
         <svg viewBox="0 0 100 100" className="w-full h-full">
           <title>Progress Donut</title>
           {/* outer translucent white circle */}
-          <circle cx="50" cy="50" r="30" fill="white" fillOpacity="0.5" />
+          <circle
+            cx="50"
+            cy="50"
+            r="30"
+            fill="var(--donut-outer)"
+            fillOpacity="0.9"
+          />
           {/* inner white circle */}
-          <circle cx="50" cy="50" r="25" fill="white" fillOpacity="0.9" />
+          <circle
+            cx="50"
+            cy="50"
+            r="25"
+            fill="var(--donut-inner)"
+            fillOpacity="0.9"
+          />
           {/* background arc track - semicircle */}
           <circle
             cx="50"
@@ -73,7 +87,7 @@ export function ProgressDonut({
           />
         </svg>
         <div className="absolute inset-0 flex flex-col items-center justify-center">
-          <span className="text-xl font-semibold">
+          <span className="text-xl font-semibold" style={{ color: valueColor }}>
             {progress_value}
             {display_unit}
           </span>

--- a/apps/next/src/components/theme-provider.tsx
+++ b/apps/next/src/components/theme-provider.tsx
@@ -28,8 +28,17 @@ const theme = createTheme({
     dark: {
       palette: {
         primary: {
-          main: twColors.sky["800"],
+          main: twColors.blue["300"],
         },
+        background: {
+          default: twColors.zinc["800"],
+          paper: twColors.zinc["700"],
+        },
+        text: {
+          primary: twColors.zinc["50"],
+          secondary: twColors.zinc["50"], //twColors.zinc["400"],
+        },
+        divider: twColors.zinc["700"],
       },
     },
   },

--- a/apps/next/src/components/ui/calendar-view.tsx
+++ b/apps/next/src/components/ui/calendar-view.tsx
@@ -17,6 +17,7 @@ import { enUS } from "date-fns/locale";
 import { Calendar, dateFnsLocalizer } from "react-big-calendar";
 import EventDialogContent from "./event-dialog-content";
 import EventDrawerContent from "./event-drawer-content";
+// @ts-ignore
 import "react-big-calendar/lib/css/react-big-calendar.css";
 
 const locales = {
@@ -66,10 +67,10 @@ const CalendarView = ({
     isSameMonth(currentDate, new Date());
 
   return (
-    <div className="border-2 border-sky-700 p-4 rounded-lg bg-white dark:bg-zinc-950 transition-colors events-calendar-wrapper">
+    <div className="border border-sky-700 dark:border-blue-300 p-4 rounded-lg bg-white dark:bg-[#27272A] transition-colors events-calendar-wrapper">
       {/* CUSTOM TOOLBAR */}
       <div className="flex items-center justify-center">
-        <div className="text-center flex items-center justify-center text-sky-700 font-medium">
+        <div className="text-center flex items-center justify-center text-sky-700 dark:text-blue-300 font-medium">
           <ArrowBackIosIcon
             className="mb-6 mr-4 cursor-pointer"
             onClick={onPreviousMonth}

--- a/apps/next/src/components/ui/card/event-card.tsx
+++ b/apps/next/src/components/ui/card/event-card.tsx
@@ -2,7 +2,7 @@
 
 import { AccessTime, PinDrop } from "@mui/icons-material";
 import CalendarTodayOutlinedIcon from "@mui/icons-material/CalendarTodayOutlined";
-import { Card, CardContent, Dialog, Drawer } from "@mui/material";
+import { Card, CardContent, Dialog, Drawer, Typography } from "@mui/material";
 import Image from "next/image";
 import React from "react";
 import EventTypeBadge from "@/components/ui/event-type-badge";
@@ -66,8 +66,8 @@ const EventCardContent = React.forwardRef<
   return (
     <div ref={ref} {...divProps}>
       <Card
-        className="cursor-pointer hover:shadow-lg transition h-full min-w-[280px] sm:min-w-0 dark:bg-zinc-900 dark:border-zinc-800"
-        sx={{ borderRadius: "6px" }}
+        className="cursor-pointer hover:shadow-lg transition h-full min-w-[280px] sm:min-w-0 dark:bg-[#303035]"
+        sx={{ borderRadius: "16px" }}
       >
         <div className="p-7 pb-2 relative">
           <Image
@@ -81,9 +81,9 @@ const EventCardContent = React.forwardRef<
         </div>
         <CardContent className="flex flex-col gap-2 p-4">
           <div className="flex flex-row gap-2 items-center">
-            <h3 className="text-lg font-semibold text-sky-700 dark:text-sky-400">
+            <Typography className="text-lg font-semibold text-sky-700 dark:text-blue-300">
               {props.name}
-            </h3>
+            </Typography>
             {props.isOngoing && <OngoingBadge />}
           </div>
           <div className="flex flex-col gap-2 text-sm text-zinc-500 dark:text-zinc-400 mt-1">
@@ -108,9 +108,9 @@ const EventCardContent = React.forwardRef<
               <span>{toTitleCase(HallEnum[props.location])}</span>
             </div>
           </div>
-          <p className="text-sm text-zinc-900 dark:text-zinc-100 mt-2">
+          <Typography color="text.primary" className="text-sm mt-2">
             {props.longDesc}
-          </p>
+          </Typography>
         </CardContent>
       </Card>
     </div>

--- a/apps/next/src/components/ui/card/event-card.tsx
+++ b/apps/next/src/components/ui/card/event-card.tsx
@@ -67,7 +67,7 @@ const EventCardContent = React.forwardRef<
     <div ref={ref} {...divProps}>
       <Card
         className="cursor-pointer hover:shadow-lg transition h-full min-w-[280px] sm:min-w-0 dark:bg-[#303035]"
-        sx={{ borderRadius: "16px" }}
+        sx={{ borderRadius: "16px", backgroundImage: "none" }}
       >
         <div className="p-7 pb-2 relative">
           <Image
@@ -81,7 +81,7 @@ const EventCardContent = React.forwardRef<
         </div>
         <CardContent className="flex flex-col gap-2 p-4">
           <div className="flex flex-row gap-2 items-center">
-            <Typography className="text-lg font-semibold text-sky-700 dark:text-blue-300">
+            <Typography className="text-lg font-semibold" color="primary">
               {props.name}
             </Typography>
             {props.isOngoing && <OngoingBadge />}

--- a/apps/next/src/components/ui/card/food-card.tsx
+++ b/apps/next/src/components/ui/card/food-card.tsx
@@ -102,10 +102,10 @@ const FoodCardContent = React.forwardRef<HTMLDivElement, FoodCardContentProps>(
         ref={ref}
         {...divProps}
         className={cn(
-          "relative cursor-pointer hover:shadow-lg transition w-full border",
+          "relative cursor-pointer hover:shadow-lg transition w-full dark:bg-[#303035]",
           doesNotMeetPreferences && "opacity-70",
         )}
-        sx={{ borderRadius: "12px" }}
+        sx={{ borderRadius: "12px", border: 1, borderColor: "divider" }}
       >
         <CardContent sx={{ padding: 0, "&:last-child": { paddingBottom: 0 } }}>
           <div className="flex justify-between h-full w-full p-4 gap-4">
@@ -126,7 +126,7 @@ const FoodCardContent = React.forwardRef<HTMLDivElement, FoodCardContentProps>(
                 />
               )}
               {!isCompact && !showImage && IconComponent && (
-                <IconComponent className="w-12 h-12 text-zinc-700 dark:text-zinc-400 flex-shrink-0" />
+                <IconComponent className="w-12 h-12 flex-shrink-0" color="primary"/>
               )}
               <div
                 className={cn(
@@ -136,8 +136,9 @@ const FoodCardContent = React.forwardRef<HTMLDivElement, FoodCardContentProps>(
                 )}
               >
                 <Typography
+                  color="primary"
                   className={cn(
-                    "font-semibold text-base text-sky-700 dark:text-sky-600",
+                    "font-semibold text-base",
                     isCompact && "font-bold",
                   )}
                   noWrap
@@ -153,7 +154,7 @@ const FoodCardContent = React.forwardRef<HTMLDivElement, FoodCardContentProps>(
                 <div className="flex gap-2 items-center text-zinc-700 text-sm w-fit flex-shrink">
                   <Typography
                     noWrap
-                    className="text-zinc-900 dark:text-zinc-300 font-normal"
+                    color="text.primary" className="font-normal"
                   >
                     {dish.nutritionInfo.calories == null
                       ? "-"
@@ -172,9 +173,10 @@ const FoodCardContent = React.forwardRef<HTMLDivElement, FoodCardContentProps>(
                 </div>
                 <Typography
                   noWrap
+                  color="text.primary"
                   className={cn(
-                    "text-zinc-900 text-sm font-normal dark:text-zinc-300",
-                    !dish.description && "italic text-zinc-700",
+                    "text-sm font-normal",
+                    !dish.description && "italic",
                   )}
                 >
                   {dish.description

--- a/apps/next/src/components/ui/card/food-card.tsx
+++ b/apps/next/src/components/ui/card/food-card.tsx
@@ -105,7 +105,12 @@ const FoodCardContent = React.forwardRef<HTMLDivElement, FoodCardContentProps>(
           "relative cursor-pointer hover:shadow-lg transition w-full dark:bg-[#303035]",
           doesNotMeetPreferences && "opacity-70",
         )}
-        sx={{ borderRadius: "12px", border: 1, borderColor: "divider" }}
+        sx={{
+          borderRadius: "12px",
+          border: 1,
+          borderColor: "divider",
+          backgroundImage: "none",
+        }}
       >
         <CardContent sx={{ padding: 0, "&:last-child": { paddingBottom: 0 } }}>
           <div className="flex justify-between h-full w-full p-4 gap-4">
@@ -126,7 +131,10 @@ const FoodCardContent = React.forwardRef<HTMLDivElement, FoodCardContentProps>(
                 />
               )}
               {!isCompact && !showImage && IconComponent && (
-                <IconComponent className="w-12 h-12 flex-shrink-0" color="primary"/>
+                <IconComponent
+                  className="w-12 h-12 flex-shrink-0"
+                  color="primary"
+                />
               )}
               <div
                 className={cn(
@@ -154,7 +162,8 @@ const FoodCardContent = React.forwardRef<HTMLDivElement, FoodCardContentProps>(
                 <div className="flex gap-2 items-center text-zinc-700 text-sm w-fit flex-shrink">
                   <Typography
                     noWrap
-                    color="text.primary" className="font-normal"
+                    color="text.primary"
+                    className="font-normal"
                   >
                     {dish.nutritionInfo.calories == null
                       ? "-"

--- a/apps/next/src/components/ui/card/my-foods-card.tsx
+++ b/apps/next/src/components/ui/card/my-foods-card.tsx
@@ -7,7 +7,7 @@ import {
   Star,
   StarBorder,
 } from "@mui/icons-material";
-import { Card, CardContent, Dialog, Drawer } from "@mui/material";
+import { Card, CardContent, Dialog, Drawer, Typography } from "@mui/material";
 import type { DishInfo } from "@peterplate/api";
 import Image from "next/image";
 import React from "react";
@@ -42,7 +42,7 @@ function UserRatingDisplay({
     }
 
     return (
-      <span className="text-sm whitespace-nowrap text-gray-500">
+      <span className="text-sm whitespace-nowrap text-gray-500 dark:text-zinc-400">
         Not rated yet
       </span>
     );
@@ -51,7 +51,13 @@ function UserRatingDisplay({
   return (
     <div className="flex items-center gap-1.5 flex-shrink-0">
       {showLabel && (
-        <span className="text-sm whitespace-nowrap">Your rating:</span>
+        <Typography
+          variant="body2"
+          color="text.primary"
+          className="whitespace-nowrap"
+        >
+          Your rating:
+        </Typography>
       )}
       <div className="flex gap-0.5 items-center">
         {[1, 2, 3, 4, 5].map((n) =>
@@ -121,14 +127,19 @@ const MyFoodsCardContent = React.forwardRef<
     return (
       <div ref={ref} {...divProps} className={cn("w-full", className)}>
         <Card
-          className="cursor-pointer hover:shadow-lg transition w-full border"
-          sx={{ borderRadius: "16px" }}
+          className="cursor-pointer hover:shadow-lg transition w-full dark:bg-[#323235]"
+          sx={{
+            borderRadius: "16px",
+            border: 1,
+            borderColor: "divider",
+            backgroundImage: "none",
+          }}
         >
           <CardContent sx={{ padding: "0 !important" }}>
             <div className="flex flex-col">
               <div className="flex items-start gap-3 p-4 pb-3">
                 {/* Thumbnail */}
-                <div className="flex-shrink-0 w-[96px] h-[96px] rounded-lg overflow-hidden bg-slate-100 flex items-center justify-center">
+                <div className="flex-shrink-0 w-[96px] h-[96px] rounded-lg overflow-hidden bg-slate-100 dark:bg-zinc-700 flex items-center justify-center">
                   {showImage ? (
                     <Image
                       src={dish.image_url}
@@ -139,7 +150,7 @@ const MyFoodsCardContent = React.forwardRef<
                       onError={() => setImageError(true)}
                     />
                   ) : IconComponent ? (
-                    <IconComponent className="w-10 h-10 text-slate-700" />
+                    <IconComponent className="w-10 h-10 text-slate-700 dark:text-blue-300" />
                   ) : (
                     <div className="w-10 h-10 bg-slate-200 rounded" />
                   )}
@@ -149,9 +160,12 @@ const MyFoodsCardContent = React.forwardRef<
                 <div className="flex-1 min-w-0 flex flex-col gap-1">
                   {/* Name row and heart */}
                   <div className="flex items-start justify-between gap-2">
-                    <span className="font-bold text-base text-sky-700 leading-snug">
+                    <Typography
+                      color="primary"
+                      className="font-bold text-base leading-snug"
+                    >
                       {formatFoodName(dish.name)}
-                    </span>
+                    </Typography>
                     <button
                       type="button"
                       aria-label={
@@ -177,14 +191,18 @@ const MyFoodsCardContent = React.forwardRef<
 
                   {/* Calories and average rating */}
                   <div className="flex items-center gap-2 text-sm flex-wrap">
-                    <span className="text-slate-900 font-normal">
+                    <Typography
+                      variant="body2"
+                      color="text.primary"
+                      className="font-normal"
+                    >
                       {dish.nutritionInfo.calories == null
                         ? "-"
                         : `${Math.round(parseFloat(dish.nutritionInfo.calories))} cal`}
-                    </span>
-                    <div className="flex items-center gap-0.5 text-zinc-500">
+                    </Typography>
+                    <div className="flex items-center gap-0.5 text-zinc-500 dark:text-zinc-400">
                       <StarBorder
-                        className="w-3.5 h-3.5 stroke-zinc-500"
+                        className="w-3.5 h-3.5 stroke-zinc-500 dark:stroke-zinc-400"
                         strokeWidth={0.15}
                       />
                       <span>
@@ -195,19 +213,23 @@ const MyFoodsCardContent = React.forwardRef<
 
                   {/* Description */}
                   {dish.description && (
-                    <p className="text-slate-700 text-sm line-clamp-2 leading-snug">
+                    <Typography
+                      variant="body2"
+                      color="text.primary"
+                      className="line-clamp-2 leading-snug"
+                    >
                       {dish.description}
-                    </p>
+                    </Typography>
                   )}
                 </div>
               </div>
 
               {/* Divider */}
-              <div className="h-px bg-sky-700 mx-4" />
+              <div className="h-px bg-sky-700 dark:bg-blue-300 mx-4" />
 
               {/* Location and user rating */}
               <div className="flex items-center justify-between px-4 py-4 gap-2">
-                <div className="flex items-center gap-1 text-gray-500 text-sm min-w-0">
+                <div className="flex items-center gap-1 text-gray-500 dark:text-zinc-400 text-sm min-w-0">
                   <LocationOn className="w-5 h-5 flex-shrink-0" />
                   <span>
                     {toTitleCase(dish.restaurant)}

--- a/apps/next/src/components/ui/card/popular-dish-card.tsx
+++ b/apps/next/src/components/ui/card/popular-dish-card.tsx
@@ -1,6 +1,6 @@
 import type { DishInfo } from "@api/index";
 import { Star } from "@mui/icons-material";
-import { Card, Dialog } from "@mui/material";
+import { Box, Card, Dialog, Typography } from "@mui/material";
 import Image from "next/image";
 import { useState } from "react";
 import { formatFoodName, getFoodIcon, toTitleCase } from "@/utils/funcs";
@@ -35,11 +35,15 @@ export default function PopularDishCard({
   return (
     <>
       <Card
-        className="w-full h-full min-h-[210px] flex flex-col rounded-xl border border-neutral-200 dark:border-neutral-700 overflow-hidden shadow-sm hover:shadow-md transition cursor-pointer text-left bg-transparent p-0"
+        className="w-full h-full min-h-[210px] flex flex-col rounded-xl overflow-hidden shadow-sm hover:shadow-md transition cursor-pointer text-left bg-transparent p-0"
+        sx={{ border: 1, borderColor: "divider" }}
         onClick={() => setOpen(true)}
       >
         {/* Dish image */}
-        <div className="relative w-full aspect-[16/9] flex-shrink-0 bg-amber-50 dark:bg-neutral-800">
+        <Box
+          className="relative w-full aspect-[16/9] flex-shrink-0"
+          sx={{ bgcolor: "background.paper" }}
+        >
           {dish.image_url ? (
             <Image
               src={dish.image_url}
@@ -50,26 +54,29 @@ export default function PopularDishCard({
             />
           ) : (
             <div className="flex items-center justify-center w-full h-full">
-              <IconComponent
-                style={{ fontSize: 48 }}
-                className="text-slate-700"
-              />
+              <IconComponent style={{ fontSize: 48 }} color="primary" />
             </div>
           )}
-        </div>
+        </Box>
         <div className="flex flex-col flex-1 p-4">
-          <h3 className="text-sm font-semibold text-sky-700 leading-tight line-clamp-2 mb-1">
-            {formatFoodName(dish.name)}
-          </h3>
-          <p
-            className={`${descSize} text-neutral-500 dark:text-neutral-400 mb-1`}
+          <Typography
+            className="text-sm font-semibold leading-tight line-clamp-2 mb-1"
+            color="primary"
           >
+            {formatFoodName(dish.name)}
+          </Typography>
+          <Typography className={`${descSize} mb-1`} color="text.secondary">
             {hallName} • {toTitleCase(stationName)}
-          </p>
-          <div className="flex items-center gap-1 text-xs text-neutral-400 mt-auto">
+          </Typography>
+          <Box
+            className="flex items-center gap-1 mt-auto"
+            sx={{ color: "text.secondary" }}
+          >
             <Star style={{ fontSize: iconSize }} />
-            <span>{averageRating > 0 ? averageRating.toFixed(1) : "—"}</span>
-          </div>
+            <Typography variant="caption">
+              {averageRating > 0 ? averageRating.toFixed(1) : "—"}
+            </Typography>
+          </Box>
         </div>
       </Card>
       <Dialog

--- a/apps/next/src/components/ui/card/ratings-card.tsx
+++ b/apps/next/src/components/ui/card/ratings-card.tsx
@@ -6,7 +6,13 @@
 "use client";
 
 import { Delete, Restaurant } from "@mui/icons-material";
-import { Card, CardContent, Dialog, IconButton } from "@mui/material";
+import {
+  Card,
+  CardContent,
+  Dialog,
+  IconButton,
+  Typography,
+} from "@mui/material";
 import type { DishInfo } from "@peterplate/api";
 import React from "react";
 import { useUserStore } from "@/context/useUserStore";
@@ -36,18 +42,20 @@ const RatingsCardContent = React.forwardRef<
   return (
     <div ref={ref} {...divProps} className={cn("w-full", className)}>
       <Card
-        className="cursor-pointer hover:shadow-lg transition w-full border"
-        sx={{ borderRadius: "16px" }}
+        className="cursor-pointer hover:shadow-lg transition w-full dark:bg-[#303035]"
+        sx={{ borderRadius: "16px", border: 1, borderColor: "divider" }}
       >
         <CardContent sx={{ padding: "0 !important" }}>
           <div className="flex justify-between items-center h-full p-6">
             <div className="flex items-center gap-6">
-              <IconComponent className="w-10 h-10 text-foreground" />
+              <IconComponent className="w-10 h-10" color="primary" />
               <div className="flex flex-col">
-                <strong>{formatFoodName(food.name)}</strong>
-                <span className="text-muted-foreground text-xs mt-1">
+                <strong className="text-sky-700 dark:text-blue-300">
+                  {formatFoodName(food.name)}
+                </strong>
+                <Typography variant="caption" color="text.secondary">
                   Rated {new Date(food.ratedAt).toLocaleDateString()}
-                </span>
+                </Typography>
               </div>
             </div>
             <div

--- a/apps/next/src/components/ui/card/search-meal-card.tsx
+++ b/apps/next/src/components/ui/card/search-meal-card.tsx
@@ -6,7 +6,7 @@ import {
   ArrowDropUp,
   Restaurant,
 } from "@mui/icons-material";
-import { Card, CardContent } from "@mui/material";
+import { Card, CardContent, Typography } from "@mui/material";
 import type { SelectLoggedMeal } from "@peterplate/db";
 import Image from "next/image";
 import React from "react";
@@ -62,9 +62,11 @@ export default function SearchMealCard({ meal, isUnavailable, onAdd }: Props) {
       <Card
         className={cn(
           "cursor-pointer transition w-full border",
-          isUnavailable ? "bg-zinc-200/90" : "bg-white hover:shadow-lg",
+          isUnavailable
+            ? "bg-zinc-200/90 dark:bg-zinc-700"
+            : "bg-white dark:bg-[#303035] hover:shadow-lg",
         )}
-        sx={{ borderRadius: "12px" }}
+        sx={{ borderRadius: "12px", backgroundImage: "none" }}
       >
         <CardContent sx={{ padding: "0 !important" }}>
           <div className="h-auto p-3 md:h-40 md:p-4 flex justify-between gap-3 text-left">
@@ -80,14 +82,18 @@ export default function SearchMealCard({ meal, isUnavailable, onAdd }: Props) {
                     onError={() => setImageError(true)}
                   />
                 ) : (
-                  <IconComponent className="w-12 h-12 text-slate-700 flex-shrink-0" />
+                  <IconComponent className="w-12 h-12 text-slate-700 dark:text-blue-300 flex-shrink-0" />
                 )}
 
                 <div className="min-w-0">
-                  <h3 className="text-sky-700 font-semibold text-lg truncate">
+                  <Typography
+                    color="primary"
+                    fontWeight={600}
+                    className="text-lg truncate"
+                  >
                     {meal.dishName}
-                  </h3>
-                  <div className="flex items-center gap-2 text-xs text-zinc-500">
+                  </Typography>
+                  <div className="flex items-center gap-2 text-xs text-zinc-500 dark:text-white">
                     <div
                       className={cn(
                         "inline-flex items-stretch rounded-md ring-1",
@@ -159,7 +165,7 @@ export default function SearchMealCard({ meal, isUnavailable, onAdd }: Props) {
               </div>
 
               {/* Nutrition content */}
-              <div className="flex gap-4 text-sm text-zinc-600">
+              <div className="flex gap-4 text-sm text-zinc-600 dark:text-zinc-400">
                 <span>{Math.round(meal.calories * servingsDraft)} cal</span>
                 <span>{Math.round(meal.protein * servingsDraft)}g protein</span>
                 <span>{Math.round(meal.carbs * servingsDraft)}g carbs</span>
@@ -177,7 +183,7 @@ export default function SearchMealCard({ meal, isUnavailable, onAdd }: Props) {
                     onAdd?.(meal, servingsDraft);
                   }
                 }}
-                className="shrink-0 p-2 text-zinc-500 hover:text-sky-600 transition"
+                className="shrink-0 p-2 text-zinc-500 dark:text-zinc-400 hover:text-sky-600 dark:hover:text-zinc-300 transition"
                 aria-label={`Add ${meal.dishName} to tracker`}
               >
                 <Add fontSize="small" />

--- a/apps/next/src/components/ui/card/tracked-meal-card.tsx
+++ b/apps/next/src/components/ui/card/tracked-meal-card.tsx
@@ -6,7 +6,7 @@ import {
   Delete,
   Restaurant,
 } from "@mui/icons-material";
-import { Card, CardContent, Dialog, Drawer } from "@mui/material";
+import { Card, CardContent, Dialog, Drawer, Typography } from "@mui/material";
 import type { SelectLoggedMeal } from "@peterplate/db";
 import Image from "next/image";
 import React from "react";
@@ -77,9 +77,11 @@ const TrackedMealCardContent = React.forwardRef<
         <Card
           className={cn(
             "cursor-pointer transition w-full border",
-            isUnavailable ? "bg-zinc-200/90" : "bg-white hover:shadow-lg",
+            isUnavailable
+              ? "bg-zinc-200/90 dark:bg-zinc-700"
+              : "bg-white dark:bg-[#303035] hover:shadow-lg",
           )}
-          sx={{ borderRadius: "12px" }}
+          sx={{ borderRadius: "12px", backgroundImage: "none" }}
         >
           <CardContent sx={{ padding: "0 !important" }}>
             <div className="h-auto p-3 md:h-40 md:p-4 flex justify-between gap-3 text-left">
@@ -95,16 +97,20 @@ const TrackedMealCardContent = React.forwardRef<
                       onError={() => setImageError(true)}
                     />
                   ) : (
-                    <IconComponent className="w-12 h-12 text-slate-700 flex-shrink-0" />
+                    <IconComponent className="w-12 h-12 text-slate-700 dark:text-blue-300 flex-shrink-0" />
                   )}
 
                   <div className="min-w-0">
-                    <h3 className="text-sky-700 font-semibold text-lg truncate">
+                    <Typography
+                      color="primary"
+                      fontWeight={600}
+                      className="text-lg truncate"
+                    >
                       {meal.dishName}
-                    </h3>
+                    </Typography>
 
                     {/* Edit Servings/Bowls */}
-                    <div className="flex items-center gap-2 text-xs text-zinc-500">
+                    <div className="flex items-center gap-2 text-xs text-zinc-500 dark:text-white">
                       <div className="inline-flex items-stretch rounded-md bg-sky-100 ring-1 ring-sky-200">
                         <div className="w-8 px-2 py-1 text-slate-900 tabular-nums leading-none flex items-center justify-center">
                           {servingsDraft}
@@ -159,7 +165,7 @@ const TrackedMealCardContent = React.forwardRef<
                   </div>
                 </div>
 
-                <div className="flex gap-4 text-sm text-zinc-600">
+                <div className="flex gap-4 text-sm text-zinc-600 dark:text-zinc-400">
                   <span>{Math.round(meal.calories * servingsDraft)} cal</span>
                   <span>
                     {Math.round(meal.protein * servingsDraft)}g protein

--- a/apps/next/src/components/ui/card/upcoming-event-card.tsx
+++ b/apps/next/src/components/ui/card/upcoming-event-card.tsx
@@ -1,5 +1,5 @@
 import { AccessTime, CalendarMonth, LocationOn } from "@mui/icons-material";
-import { Card, Dialog } from "@mui/material";
+import { Box, Card, Dialog, Typography } from "@mui/material";
 import { useState } from "react";
 import { timeToString, toTitleCase } from "@/utils/funcs";
 import { HallEnum, numToMonth } from "@/utils/types";
@@ -60,44 +60,48 @@ export default function UpcomingEventCard({
   return (
     <>
       <Card
-        className="w-full rounded-xl border border-neutral-200 dark:border-neutral-700 p-5 shadow-sm hover:shadow-md transition cursor-pointer text-left bg-transparent"
+        className="w-full rounded-xl p-5 shadow-sm hover:shadow-md transition cursor-pointer text-left bg-transparent"
+        sx={{ border: 1, borderColor: "divider" }}
         onClick={() => setOpen(true)}
       >
         <div className="mb-3 flex items-start gap-2 min-w-0">
-          <h3
-            className={`${titleSize} line-clamp-2 min-w-0 flex-1 whitespace-normal break-normal font-bold leading-tight text-sky-700`}
+          <Typography
+            className={`${titleSize} font-bold leading-tight pr-2 line-clamp-2 min-w-0 flex-1 whitespace-normal break-normal`}
+            color="primary"
           >
             {event.title}
-          </h3>
-          {/*           <span
-            className={`flex-shrink-0 ${tagSize} font-semibold uppercase tracking-wider bg-sky-100 text-sky-700 dark:bg-sky-900 dark:text-sky-300 px-2 py-0.5 rounded-full`}
+          </Typography>
+          <span
+            className={`flex-shrink-0 ${tagSize} font-semibold tracking-wider bg-sky-100 text-sky-700 dark:bg-transparent dark:border dark:border-blue-300 dark:text-blue-300 px-2 py-0.5 rounded-full`}
           >
             Celebration
-          </span> */}
+          </span>
         </div>
         <div className={spacing}>
           {startDate && (
             <>
-              <div className="flex items-center gap-1.5 text-xs text-neutral-500 dark:text-neutral-400">
+              <Box className="flex items-center gap-1.5">
                 <CalendarMonth style={{ fontSize: iconSize }} />
-                <span>
+                <Typography variant="caption" color="text.secondary">
                   {numToMonth[startDate.getMonth()]} {startDate.getDate()},{" "}
                   {startDate.getFullYear()}
-                </span>
-              </div>
-              <div className="flex items-center gap-1.5 text-xs text-neutral-500 dark:text-neutral-400">
+                </Typography>
+              </Box>
+              <Box className="flex items-center gap-1.5">
                 <AccessTime style={{ fontSize: iconSize }} />
-                <span>
+                <Typography variant="caption" color="text.secondary">
                   {timeToString(startDate)}
                   {endDate ? ` - ${timeToString(endDate)}` : ""}
-                </span>
-              </div>
+                </Typography>
+              </Box>
             </>
           )}
-          <div className="flex items-center gap-1.5 text-xs text-neutral-500 dark:text-neutral-400">
+          <Box className="flex items-center gap-1.5">
             <LocationOn style={{ fontSize: iconSize }} />
-            <span>{toTitleCase(event.restaurantId)}</span>
-          </div>
+            <Typography variant="caption" color="text.secondary">
+              {toTitleCase(event.restaurantId)}
+            </Typography>
+          </Box>
         </div>
       </Card>
       <Dialog

--- a/apps/next/src/components/ui/dishes-info.tsx
+++ b/apps/next/src/components/ui/dishes-info.tsx
@@ -1,6 +1,7 @@
 "use client";
 "use client";
 
+import { Typography } from "@mui/material";
 import type { DishInfo } from "@peterplate/api";
 import type React from "react";
 import { useUserStore } from "@/context/useUserStore";
@@ -85,9 +86,13 @@ export default function DishesInfo({
       {!isLoading &&
         !isError &&
         (dishes.length === 0 ? (
-          <p className="text-center text-gray-500 py-4">
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            className="text-center py-4"
+          >
             No dishes available for this selection.
-          </p>
+          </Typography>
         ) : isCompactView ? (
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
             {dishes.map((dish) => (

--- a/apps/next/src/components/ui/event-dialog-content.tsx
+++ b/apps/next/src/components/ui/event-dialog-content.tsx
@@ -1,11 +1,11 @@
 import AccessTimeOutlinedIcon from "@mui/icons-material/AccessTimeOutlined";
 import CalendarTodayOutlinedIcon from "@mui/icons-material/CalendarTodayOutlined";
 import PinDropOutlinedIcon from "@mui/icons-material/PinDropOutlined";
-import { Button, DialogContent } from "@mui/material";
+import { Box, Button, DialogContent, Typography } from "@mui/material";
 import Image from "next/image";
 import type React from "react";
 import EventTypeBadge from "@/components/ui/event-type-badge";
-import { generateGCalLink, timeToString, toTitleCase } from "@/utils/funcs";
+import { generateGCalLink, dateToString, timeToString, toTitleCase } from "@/utils/funcs";
 import { HallEnum } from "@/utils/types";
 import type { EventInfo } from "./card/event-card";
 
@@ -22,7 +22,7 @@ export default function EventDialogContent(
   props: EventInfo,
 ): React.JSX.Element {
   return (
-    <>
+    <Box className="dark:bg-[#303035]">
       <div className="relative">
         <Image
           src={props.imgSrc}
@@ -35,21 +35,24 @@ export default function EventDialogContent(
       </div>
       <DialogContent
         sx={{ padding: "20px 24px 24px !important" }}
-        className="flex flex-col gap-2 dark:bg-zinc-800 dark:text-zinc-400"
+        className="flex flex-col gap-2"
       >
-        <h2 className="text-2xl font-semibold text-sky-700 leading-tight">
+        <Typography
+          fontWeight={600}
+          color="primary"
+          className="leading-tight tracking-normal text-left"
+          sx={{ fontSize: "1.875rem" }}
+        >
           {props.name}
-        </h2>
-        <div className="flex flex-col gap-2 text-sm text-zinc-500 mt-1">
-          <div className="flex gap-2 items-center">
-            <CalendarTodayOutlinedIcon sx={{ fontSize: 16 }} />
-            <span>
-              {props.startTime.toLocaleDateString(undefined, {
-                year: "numeric",
-                month: "long",
-                day: "numeric",
-              })}
-            </span>
+        </Typography>
+        <Box
+          className="flex flex-wrap gap-x-2 gap-y-1 items-center"
+          id="event-card-subheader"
+          sx={{ color: "text.secondary" }}
+        >
+          <div className="flex gap-1 items-center whitespace-nowrap">
+            <AccessTimeOutlinedIcon fontSize="small" />
+            <p>{dateToString(props.startTime, props.endTime)}</p>
           </div>
           <div className="flex gap-2 items-center">
             <AccessTimeOutlinedIcon sx={{ fontSize: 16 }} />
@@ -61,9 +64,35 @@ export default function EventDialogContent(
             <PinDropOutlinedIcon sx={{ fontSize: 16 }} />
             <span>{toTitleCase(HallEnum[props.location])}</span>
           </div>
+        </Box>
+        <Typography
+          variant="body2"
+          className="leading-relaxed mt-2"
+          color="text.primary"
+        >
+          {props.longDesc}
+        </Typography>
+        <div className="w-full flex items-center justify-center pt-4">
+          <a
+            href={generateGCalLink(
+              props.name,
+              props.longDesc,
+              props.location,
+              props.startTime,
+            )}
+            rel="noreferrer"
+            target="_blank"
+          >
+            <Button
+              variant="contained"
+              className="[&_svg]:size-5 whitespace-nowrap"
+              startIcon={<CalendarTodayOutlinedIcon />}
+            >
+              Add to Google Calendar
+            </Button>
+          </a>
         </div>
-        <p className="text-sm leading-relaxed mt-2">{props.longDesc}</p>
       </DialogContent>
-    </>
+    </Box>
   );
 }

--- a/apps/next/src/components/ui/event-dialog-content.tsx
+++ b/apps/next/src/components/ui/event-dialog-content.tsx
@@ -46,9 +46,8 @@ export default function EventDialogContent(
           {props.name}
         </Typography>
         <Box
-          className="flex flex-wrap gap-x-2 gap-y-1 items-center"
+          className="flex flex-wrap gap-x-2 gap-y-1 items-center text-zinc-500 dark:text-zinc-400"
           id="event-card-subheader"
-          sx={{ color: "text.secondary" }}
         >
           <div className="flex gap-1 items-center whitespace-nowrap">
             <AccessTimeOutlinedIcon fontSize="small" />

--- a/apps/next/src/components/ui/event-drawer-content.tsx
+++ b/apps/next/src/components/ui/event-drawer-content.tsx
@@ -1,7 +1,7 @@
 import AccessTimeOutlinedIcon from "@mui/icons-material/AccessTimeOutlined";
 import CalendarTodayOutlinedIcon from "@mui/icons-material/CalendarTodayOutlined";
 import PinDropOutlinedIcon from "@mui/icons-material/PinDropOutlined";
-import { Box } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import Image from "next/image";
 import EventTypeBadge from "@/components/ui/event-type-badge";
 import { timeToString, toTitleCase } from "@/utils/funcs";
@@ -21,7 +21,7 @@ export default function EventDrawerContent(
   props: EventInfo,
 ): React.JSX.Element {
   return (
-    <Box>
+    <Box className="dark:bg-[#303035]">
       <div className="relative">
         <Image
           src={props.imgSrc}
@@ -33,10 +33,15 @@ export default function EventDrawerContent(
         <EventTypeBadge title={props.name} />
       </div>
       <Box sx={{ padding: "20px 24px 24px" }} className="flex flex-col gap-2">
-        <h2 className="text-2xl font-semibold text-sky-700 leading-tight">
+        <Typography
+          fontWeight={600}
+          color="primary"
+          sx={{ fontSize: "1.5rem" }}
+          className="leading-tight"
+        >
           {props.name}
-        </h2>
-        <div className="flex flex-col gap-2 text-sm text-zinc-500 mt-1">
+        </Typography>
+        <div className="flex flex-col gap-2 text-sm text-zinc-500 dark:text-zinc-400 mt-1">
           <div className="flex gap-2 items-center">
             <CalendarTodayOutlinedIcon sx={{ fontSize: 16 }} />
             <span>
@@ -58,9 +63,13 @@ export default function EventDrawerContent(
             <span>{toTitleCase(HallEnum[props.location])}</span>
           </div>
         </div>
-        <p className="text-sm leading-relaxed mt-2">
+        <Typography
+          variant="body2"
+          color="text.primary"
+          className="leading-relaxed mt-2"
+        >
           {props.longDesc?.replace(/\u00A0+/g, " ")}
-        </p>
+        </Typography>
       </Box>
     </Box>
   );

--- a/apps/next/src/components/ui/event-type-badge.tsx
+++ b/apps/next/src/components/ui/event-type-badge.tsx
@@ -4,7 +4,7 @@ export default function EventTypeBadge({ title }: { title: string }) {
   const type = getEventType(title);
   if (type !== "celebration" && type !== "special") return null;
   return (
-    <span className="absolute bottom-3 right-3 bg-white/80 text-black text-sm font-medium px-4 py-1.5 rounded-full shadow-md">
+    <span className="absolute bottom-3 right-3 bg-white text-black dark:bg-[#303035] dark:text-white text-sm font-medium px-4 py-1.5 rounded-full shadow-md">
       {type === "celebration" ? "Celebration" : "Special Meal"}
     </span>
   );

--- a/apps/next/src/components/ui/food-dialog-content.tsx
+++ b/apps/next/src/components/ui/food-dialog-content.tsx
@@ -2,7 +2,7 @@
 
 import { Add, StarBorder } from "@mui/icons-material";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
-import { Button, DialogContent, Tooltip } from "@mui/material";
+import { Box, Button, DialogContent, Tooltip, Typography } from "@mui/material";
 import type { DishInfo } from "@peterplate/api";
 import Image from "next/image";
 import { useState } from "react";
@@ -86,7 +86,7 @@ export default function FoodDialogContent({
   const userId = useUserStore((s) => s.userId);
 
   return (
-    <div className="font-poppins flex flex-col max-h-[90vh]">
+    <div className="font-poppins flex flex-col max-h-[90vh] dark:bg-[#303035]">
       {showImage ? (
         <Image
           src={dish.image_url as string}
@@ -121,21 +121,26 @@ export default function FoodDialogContent({
                 className="flex justify-between px-4 items-center"
                 id="food-header-info"
               >
-                <div className="flex gap-3 items-center pr-2">
-                  <h2
+                <div className="flex gap-3 items-center">
+                  <Typography
+                    variant="h5"
+                    fontWeight={700}
+                    color="primary"
                     className={cn(
-                      "text-3xl font-bold leading-tight tracking-normal",
-                      "text-sky-700 dark:text-sky-600",
+                      "leading-tight tracking-normal",
                       dish.name.length > 10 && "text-2xl",
                       dish.name.length > 30 && "text-md",
                     )}
                   >
                     {formatFoodName(dish.name)}
-                  </h2>
+                  </Typography>
                 </div>
                 <Rating dishId={dish.id} />
               </div>
-              <div className="px-4 flex flex-wrap items-center gap-2 text-zinc-500 dark:text-zinc-400">
+              <Box
+                className="px-4 flex flex-wrap items-center gap-2"
+                sx={{ color: "text.secondary" }}
+              >
                 <span className="whitespace-nowrap flex items-center gap-1">
                   <StarBorder
                     className="w-4 h-4 stroke-zinc-400"
@@ -174,15 +179,22 @@ export default function FoodDialogContent({
                       />
                     ))}
                 </div>
-              </div>
-              <p className="text-black dark:text-zinc-300 px-4 leading-relaxed">
+              </Box>
+              <Typography className="px-4 leading-relaxed" color="text.primary">
                 {enhanceDescription(dish.name, dish.description)}
-              </p>
+              </Typography>
               <div>
-                <h1 className="px-4 text-2xl font-bold">Nutrients</h1>
-                <div
-                  className="grid grid-cols-2 gap-x-4 w-full px-4 text-black mb-4"
+                <Typography
+                  fontWeight={700}
+                  className="px-4"
+                  sx={{ fontSize: "1.5rem" }}
+                >
+                  Nutrients
+                </Typography>
+                <Box
+                  className="grid grid-cols-2 gap-x-4 w-full px-4 mb-4"
                   id="nutrient-content"
+                  sx={{ color: "text.primary" }}
                 >
                   {caloricInformationAvailable &&
                     Object.keys(dish.nutritionInfo)
@@ -215,7 +227,7 @@ export default function FoodDialogContent({
                                 "col-span-1",
                                 (nutrientKey === "transFatG" ||
                                   nutrientKey === "saturatedFatG") &&
-                                  "text-zinc-500 pl-4",
+                                  "text-gray-500 dark:text-blue-300 pl-4",
                               )}
                             >
                               {formatNutrientLabel(nutrientKey)}
@@ -225,7 +237,7 @@ export default function FoodDialogContent({
                                 "col-span-1 text-right",
                                 (nutrientKey === "transFatG" ||
                                   nutrientKey === "saturatedFatG") &&
-                                  "text-zinc-500",
+                                  "text-gray-500 dark:text-blue-300",
                               )}
                             >
                               {value == null
@@ -235,7 +247,7 @@ export default function FoodDialogContent({
                           </div>
                         );
                       })}
-                </div>
+                </Box>
                 {!caloricInformationAvailable && (
                   <h2 className="text-center w-full my-10 text-sm text-zinc-600">
                     Nutritional information not available.

--- a/apps/next/src/components/ui/food-dialog-content.tsx
+++ b/apps/next/src/components/ui/food-dialog-content.tsx
@@ -137,10 +137,7 @@ export default function FoodDialogContent({
                 </div>
                 <Rating dishId={dish.id} />
               </div>
-              <Box
-                className="px-4 flex flex-wrap items-center gap-2"
-                sx={{ color: "text.secondary" }}
-              >
+              <Box className="px-4 flex flex-wrap items-center gap-2 text-zinc-500 dark:text-zinc-400">
                 <span className="whitespace-nowrap flex items-center gap-1">
                   <StarBorder
                     className="w-4 h-4 stroke-zinc-400"
@@ -227,7 +224,7 @@ export default function FoodDialogContent({
                                 "col-span-1",
                                 (nutrientKey === "transFatG" ||
                                   nutrientKey === "saturatedFatG") &&
-                                  "text-gray-500 dark:text-blue-300 pl-4",
+                                  "text-gray-500 dark:text-zinc-400 pl-4",
                               )}
                             >
                               {formatNutrientLabel(nutrientKey)}
@@ -237,7 +234,7 @@ export default function FoodDialogContent({
                                 "col-span-1 text-right",
                                 (nutrientKey === "transFatG" ||
                                   nutrientKey === "saturatedFatG") &&
-                                  "text-gray-500 dark:text-blue-300",
+                                  "text-gray-500 dark:text-zinc-400",
                               )}
                             >
                               {value == null
@@ -312,7 +309,7 @@ export default function FoodDialogContent({
                 <button
                   type="button"
                   disabled={true}
-                  className="w-full inline-flex h-[30px] justify-center items-center gap-0.5 rounded-md border border-gray-300 bg-white text-[12px] font-normal leading-[18px] text-zinc-500 hover:bg-zinc-50 disabled:opacity-60"
+                  className="w-full inline-flex h-[30px] justify-center items-center gap-0.5 rounded-md border border-gray-300 dark:border-zinc-600 bg-white dark:bg-transparent text-[12px] font-normal leading-[18px] text-zinc-500 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700 disabled:opacity-60"
                 >
                   <Add sx={{ fontSize: 18, width: 18, height: 18 }} />
                   Add to Meal Tracker
@@ -326,7 +323,7 @@ export default function FoodDialogContent({
                 type="button"
                 onClick={onAddToMealTracker}
                 disabled={isAddingToMealTracker}
-                className="w-full inline-flex h-[30px] justify-center items-center gap-0.5 rounded-md border border-gray-300 bg-white text-[12px] font-normal leading-[18px] text-zinc-500 hover:bg-zinc-50 disabled:opacity-60"
+                className="w-full inline-flex h-[30px] justify-center items-center gap-0.5 rounded-md border border-gray-500 dark:border-zinc-300 bg-white dark:bg-transparent text-[12px] font-normal leading-[18px] text-zinc-500 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-700 disabled:opacity-60"
                 style={{ fontFamily: "Poppins, sans-serif" }}
               >
                 <Add sx={{ fontSize: 18, width: 18, height: 18 }} />

--- a/apps/next/src/components/ui/food-drawer-content.tsx
+++ b/apps/next/src/components/ui/food-drawer-content.tsx
@@ -2,7 +2,7 @@
 
 import { Add } from "@mui/icons-material";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
-import { Box, Button } from "@mui/material";
+import { Box, Button, Typography } from "@mui/material";
 import type { DishInfo } from "@peterplate/api";
 import Image from "next/image";
 import { useState } from "react";
@@ -65,7 +65,7 @@ export default function FoodDrawerContent({
   ]);
 
   return (
-    <Box className="h-full max-h-[85vh] flex flex-col font-poppins min-h-0">
+    <Box className="h-full max-h-[85vh] flex flex-col font-poppins min-h-0 dark:bg-[#303035]">
       <Box className="pb-4 shrink-0">
         {showImage ? (
           <Image
@@ -87,19 +87,20 @@ export default function FoodDrawerContent({
         )}
         <Box className="px-4 pt-4 flex flex-col gap-2">
           <div className="flex items-center justify-between">
-            <h2
+            <Typography
+              fontWeight={700}
+              color="primary"
               className={cn(
-                "text-3xl font-bold leading-tight tracking-normal",
-                "text-sky-700 dark:text-sky-600",
+                "text-3xl leading-tight tracking-normal",
                 dish.name.length > 10 && "text-2xl",
                 dish.name.length > 30 && "text-md",
               )}
             >
               {formatFoodName(dish.name)}
-            </h2>
+            </Typography>
           </div>
 
-          <div className="flex flex-wrap items-center gap-2 text-zinc-500">
+          <div className="flex flex-wrap items-center gap-2 text-zinc-500 dark:text-zinc-400">
             <span className="whitespace-nowrap">
               {toTitleCase(dish.restaurant)} •{" "}
               {!caloricInformationAvailable
@@ -141,17 +142,24 @@ export default function FoodDrawerContent({
             <InteractiveStarRating dishId={dish.id} />
           </div>
 
-          <p className="text-black leading-relaxed">
+          <Typography color="text.primary" className="leading-relaxed">
             {enhanceDescription(dish.name, dish.description)}
-          </p>
+          </Typography>
         </Box>
       </Box>
 
       <Box className="flex-1 min-h-0 overflow-y-auto flex flex-col px-4">
-        <h1 className="text-2xl text-left font-bold mb-2">Nutrients</h1>
-        <div
-          className="grid grid-cols-2 gap-x-4 w-full px-2 text-black mb-4 auto-rows-max"
+        <Typography
+          fontWeight={700}
+          color="text.primary"
+          className="text-2xl mb-2"
+        >
+          Nutrients
+        </Typography>
+        <Box
+          className="grid grid-cols-2 gap-x-4 w-full px-2 mb-4 auto-rows-max"
           id="nutrient-content"
+          sx={{ color: "text.primary" }}
         >
           {caloricInformationAvailable &&
             Object.keys(dish.nutritionInfo)
@@ -177,7 +185,7 @@ export default function FoodDrawerContent({
                         "col-span-1 text-left",
                         (nutrientKey === "transFatG" ||
                           nutrientKey === "saturatedFatG") &&
-                          "text-gray-500 pl-4",
+                          "text-gray-500 dark:text-zinc-400 pl-4",
                       )}
                     >
                       {formatNutrientLabel(nutrientKey)}
@@ -187,7 +195,7 @@ export default function FoodDrawerContent({
                         "col-span-1 text-right",
                         (nutrientKey === "transFatG" ||
                           nutrientKey === "saturatedFatG") &&
-                          "text-gray-500",
+                          "text-gray-500 dark:text-zinc-400",
                       )}
                     >
                       {value == null
@@ -197,7 +205,7 @@ export default function FoodDrawerContent({
                   </div>
                 );
               })}
-        </div>
+        </Box>
         {!caloricInformationAvailable && (
           <h2 className="text-center w-full text-sm text-zinc-600">
             Nutritional information not available.
@@ -247,7 +255,7 @@ export default function FoodDrawerContent({
             type="button"
             onClick={onAddToMealTracker}
             disabled={isAddingToMealTracker}
-            className="w-full inline-flex h-[30px] justify-center items-center gap-0.5 rounded-md border border-gray-300 bg-white text-[12px] font-normal leading-[18px] text-zinc-500 hover:bg-zinc-50 disabled:opacity-60"
+            className="w-full inline-flex h-[30px] justify-center items-center gap-0.5 rounded-md border border-gray-300 dark:border-zinc-600 bg-white dark:bg-transparent text-[12px] font-normal leading-[18px] text-zinc-500 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-700 disabled:opacity-60"
             style={{ fontFamily: "Poppins, sans-serif" }}
           >
             <Add sx={{ fontSize: 18, width: 18, height: 18 }} />

--- a/apps/next/src/components/ui/meal-search.tsx
+++ b/apps/next/src/components/ui/meal-search.tsx
@@ -80,14 +80,14 @@ function MealList({
     return (
       <div className="flex flex-col gap-3">
         <div className="flex items-center gap-2">
-          <span className="text-xs font-semibold uppercase tracking-wide text-sky-700">
+          <span className="text-xs font-semibold uppercase tracking-wide text-sky-700 dark:text-blue-300">
             Search Results...
           </span>
-          <div className="flex-1 h-px bg-sky-100" />
+          <div className="flex-1 h-px bg-sky-100 dark:bg-blue-300/30" />
         </div>
 
         {searchResults.length === 0 ? (
-          <p className="text-zinc-400 text-sm py-6 text-center">
+          <p className="text-zinc-400 dark:text-white text-sm py-6 text-center">
             No dishes found matching &quot;{query}&quot;.
           </p>
         ) : (
@@ -120,11 +120,11 @@ function MealList({
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center gap-2">
-        <div className="flex-1 h-px bg-sky-100" />
+        <div className="flex-1 h-px bg-sky-100 dark:bg-blue-300/30" />
       </div>
 
       {suggestedMeals.length === 0 ? (
-        <p className="text-zinc-400 text-sm py-6 text-center">
+        <p className="text-zinc-400 dark:text-white text-sm py-6 text-center">
           Log a dish for it to appear here!
         </p>
       ) : (
@@ -162,15 +162,19 @@ function SearchBar({
       InputProps={{
         startAdornment: (
           <InputAdornment position="start">
-            <Search sx={{ color: colors.slate500 }} />
+            <Search sx={{ color: "var(--mui-palette-text-secondary)" }} />
           </InputAdornment>
         ),
         sx: {
-          backgroundColor: "white",
+          backgroundColor: "var(--mui-palette-background-paper)",
           borderRadius: "12px",
-          "& fieldset": { borderColor: colors.sky200 },
-          "&:hover fieldset": { borderColor: colors.sky500 },
-          "&.Mui-focused fieldset": { borderColor: colors.sky600 },
+          "& fieldset": { borderColor: "var(--mui-palette-primary-main)" },
+          "&:hover fieldset": {
+            borderColor: "var(--mui-palette-primary-main)",
+          },
+          "&.Mui-focused fieldset": {
+            borderColor: "var(--mui-palette-primary-main)",
+          },
         },
       }}
     />
@@ -218,6 +222,7 @@ function DesktopMealSearchDialog({
           backgroundColor: colors.sky100,
           padding: "12px",
           flexShrink: 0,
+          ".dark &": { backgroundColor: "#8EC5FF33" },
         }}
       >
         <div className="flex items-center gap-2">
@@ -228,7 +233,7 @@ function DesktopMealSearchDialog({
             onClick={onClose}
             size="small"
             aria-label="Close search"
-            sx={{ color: colors.sky700, flexShrink: 0 }}
+            sx={{ color: "var(--mui-palette-primary-main)", flexShrink: 0 }}
           >
             <Close fontSize="small" />
           </IconButton>
@@ -275,9 +280,13 @@ function MobileMealSearchDrawer({
           flexDirection: "column",
           overflow: "hidden",
         },
+        ".dark & .MuiDrawer-paper": {
+          backgroundImage: "none",
+          backgroundColor: "#303035",
+        },
       }}
     >
-      <div className="bg-sky-100 px-4 pt-3 pb-4 flex-shrink-0">
+      <div className="bg-sky-100 dark:bg-[#8EC5FF33] px-4 pt-3 pb-4 flex-shrink-0">
         <div className="flex items-center gap-2">
           <div className="flex-1">
             <SearchBar query={query} onChange={setQuery} />
@@ -286,7 +295,7 @@ function MobileMealSearchDrawer({
             onClick={onClose}
             size="small"
             aria-label="Close search"
-            sx={{ color: colors.sky700, flexShrink: 0 }}
+            sx={{ color: "var(--mui-palette-primary-main)", flexShrink: 0 }}
           >
             <Close fontSize="small" />
           </IconButton>
@@ -307,7 +316,7 @@ function MobileMealSearchDrawer({
         <button
           type="button"
           onClick={onClose}
-          className="bg-sky-700 text-white text-sm font-medium px-5 py-2 rounded-full hover:bg-sky-800 transition-colors"
+          className="bg-sky-700 dark:bg-blue-300 text-white dark:text-gray-900 text-sm font-medium px-5 py-2 rounded-full hover:bg-sky-800 dark:hover:bg-blue-400 transition-colors"
         >
           Close
         </button>
@@ -336,6 +345,8 @@ export default function MealSearchDialog(props: MealSearchDialogProps) {
           "&:hover": { backgroundColor: colors.sky800 },
           color: "white",
           zIndex: 50,
+          ".dark &": { backgroundColor: "#93C5FD", color: "#111827" },
+          ".dark &:hover": { backgroundColor: "#60a5fa" },
         }}
       >
         <Add fontSize="large" />

--- a/apps/next/src/components/ui/mobile-calorie-card.tsx
+++ b/apps/next/src/components/ui/mobile-calorie-card.tsx
@@ -25,18 +25,21 @@ export default function MobileCalorieCard({
   const nutrition = compileMealData(mealsEaten);
 
   return (
-    <div className="bg-sky-100 rounded-xl px-4 flex flex-row items-center justify-between h-36 w-full relative">
+    <div className="bg-sky-100 dark:bg-[#8EC5FF33] rounded-xl px-4 flex flex-row items-center justify-between h-36 w-full relative">
       <div className="absolute top-0 right-4">
         {!hideEditButton && <NutritionGoals userId={userId} date={date} />}
       </div>
-      <span className="text-3xl text-sky-700 font-medium pr-3">Calories</span>
+      <span className="text-3xl text-sky-700 dark:text-blue-300 font-medium pr-3">
+        Calories
+      </span>
       <div className="flex items-center gap-2 pr-6">
         <ProgressDonut
           progress_value={nutrition.calories}
           max_value={calorieGoal}
           display_unit=""
-          trackColor="#0084D1"
-          progressColor="#00BCFF"
+          trackColor="var(--donut-calories-track)"
+          progressColor="var(--donut-calories-progress)"
+          valueColor="var(--donut-calories-value)"
         />
       </div>
     </div>

--- a/apps/next/src/components/ui/mobile-nutrition-bars.tsx
+++ b/apps/next/src/components/ui/mobile-nutrition-bars.tsx
@@ -16,14 +16,19 @@ function MacroBar({ label, value, max, unit }: MacroBarProps) {
   const percent = Math.min((value / max) * 100, 100);
   return (
     <div className="flex items-center gap-4">
-      <span className="text-sky-700 font-semibold w-16">{label}</span>
-      <div className="flex-1 bg-white rounded-full h-3">
+      <span className="text-sky-700 dark:text-blue-300 font-semibold w-16">
+        {label}
+      </span>
+      <div className="flex-1 bg-white dark:bg-[#27272A] rounded-full h-3">
         <div
           className="h-3 rounded-full"
-          style={{ width: `${percent}%`, backgroundColor: "#0084D1" }}
+          style={{
+            width: `${percent}%`,
+            backgroundColor: "var(--mui-palette-primary-main)",
+          }}
         />
       </div>
-      <span className="text-sm text-zinc-500 w-24 text-right">
+      <span className="text-sm text-zinc-500 dark:text-white w-24 text-right">
         {Math.round(value)}
         {unit} / {max}
         {unit}
@@ -48,7 +53,7 @@ export default function MobileNutritionBars({
   const nutrition = compileMealData(mealsEaten);
 
   return (
-    <div className="bg-sky-100 rounded-xl p-4 flex flex-col gap-4 w-full">
+    <div className="bg-sky-100 dark:bg-[#8EC5FF33] rounded-xl p-4 flex flex-col gap-4 w-full">
       <MacroBar
         label="Protein"
         value={nutrition.protein_g}

--- a/apps/next/src/components/ui/nutrition-breakdown.tsx
+++ b/apps/next/src/components/ui/nutrition-breakdown.tsx
@@ -82,9 +82,10 @@ const NutritionBreakdown = ({
   };
 
   const cardBase =
-    "bg-sky-100 rounded-xl px-4 flex flex-row items-center justify-between h-36 min-w-0";
+    "bg-sky-100 dark:bg-[#8EC5FF33] rounded-xl px-4 flex flex-row items-center justify-between h-36 min-w-0";
 
-  const labelBase = "text-3xl text-sky-700 font-medium pl-3 truncate min-w-0";
+  const labelBase =
+    "text-3xl text-sky-700 dark:text-blue-300 font-medium pl-3 truncate min-w-0";
 
   return (
     <div style={gridStyle} className="mt-6">
@@ -95,8 +96,9 @@ const NutritionBreakdown = ({
             progress_value={nutrition.calories}
             max_value={calorieGoal}
             display_unit=""
-            trackColor="#0084D1"
-            progressColor="#00BCFF"
+            trackColor="var(--donut-calories-track)"
+            progressColor="var(--donut-calories-progress)"
+            valueColor="var(--donut-calories-value)"
           />
         </div>
       </div>

--- a/apps/next/src/components/ui/nutrition-goals.tsx
+++ b/apps/next/src/components/ui/nutrition-goals.tsx
@@ -82,7 +82,7 @@ export default function NutritionGoals({ userId, date }: Props) {
 
   const inputs = (
     <>
-      <label className="flex items-center justify-between gap-4 text-sm font-medium text-zinc-900">
+      <label className="flex items-center justify-between gap-4 text-sm font-medium text-zinc-900 dark:text-white">
         Calorie Goal
         <input
           type="number"
@@ -107,10 +107,10 @@ export default function NutritionGoals({ userId, date }: Props) {
           onKeyDown={(e) => {
             if (e.key === "Enter") e.currentTarget.blur();
           }}
-          className="w-24 border-b border-sky-400 bg-sky-100 rounded px-2 py-1 text-sm"
+          className="w-24 border-b border-sky-400 bg-sky-100 dark:border-blue-300 dark:bg-[#8EC5FF33] dark:text-white rounded px-2 py-1 text-sm"
         />
       </label>
-      <label className="flex items-center justify-between gap-4 text-sm font-medium text-zinc-900">
+      <label className="flex items-center justify-between gap-4 text-sm font-medium text-zinc-900 dark:text-white">
         Protein Goal
         <input
           type="number"
@@ -135,10 +135,10 @@ export default function NutritionGoals({ userId, date }: Props) {
           onKeyDown={(e) => {
             if (e.key === "Enter") e.currentTarget.blur();
           }}
-          className="w-24 border-b border-sky-400 bg-sky-100 rounded px-2 py-1 text-sm"
+          className="w-24 border-b border-sky-400 bg-sky-100 dark:border-blue-300 dark:bg-[#8EC5FF33] dark:text-white rounded px-2 py-1 text-sm"
         />
       </label>
-      <label className="flex items-center justify-between gap-4 text-sm font-medium text-zinc-900">
+      <label className="flex items-center justify-between gap-4 text-sm font-medium text-zinc-900 dark:text-white">
         Carb Goal
         <input
           type="number"
@@ -163,10 +163,10 @@ export default function NutritionGoals({ userId, date }: Props) {
           onKeyDown={(e) => {
             if (e.key === "Enter") e.currentTarget.blur();
           }}
-          className="w-24 border-b border-sky-400 bg-sky-100 rounded px-2 py-1 text-sm"
+          className="w-24 border-b border-sky-400 bg-sky-100 dark:border-blue-300 dark:bg-[#8EC5FF33] dark:text-white rounded px-2 py-1 text-sm"
         />
       </label>
-      <label className="flex items-center justify-between gap-4 text-sm font-medium text-zinc-900">
+      <label className="flex items-center justify-between gap-4 text-sm font-medium text-zinc-900 dark:text-white">
         Fat Goal
         <input
           type="number"
@@ -191,7 +191,7 @@ export default function NutritionGoals({ userId, date }: Props) {
           onKeyDown={(e) => {
             if (e.key === "Enter") e.currentTarget.blur();
           }}
-          className="w-24 border-b border-sky-400 bg-sky-100 rounded px-2 py-1 text-sm"
+          className="w-24 border-b border-sky-400 bg-sky-100 dark:border-blue-300 dark:bg-[#8EC5FF33] dark:text-white rounded px-2 py-1 text-sm"
         />
       </label>
     </>
@@ -202,18 +202,28 @@ export default function NutritionGoals({ userId, date }: Props) {
       <Button
         onClick={() => setOpen(!open)}
         variant="contained"
-        className="!bg-sky-700 !text-white hover:!bg-sky-800 !rounded-lg !min-w-0 !p-1 md:!p-2"
+        className="!bg-sky-700 !text-white hover:!bg-sky-800 !rounded-lg !min-w-0 !p-1 md:!p-2 dark:!bg-blue-300 dark:!text-gray-900 dark:hover:!bg-blue-400"
       >
         <EditIcon />
       </Button>
 
       {isMobile ? (
-        <Drawer anchor="bottom" open={open} onClose={() => setOpen(false)}>
+        <Drawer
+          anchor="bottom"
+          open={open}
+          onClose={() => setOpen(false)}
+          sx={{
+            ".dark & .MuiDrawer-paper": {
+              backgroundImage: "none",
+              backgroundColor: "#323235",
+            },
+          }}
+        >
           <div className="p-6 flex flex-col gap-4">{inputs}</div>
         </Drawer>
       ) : (
         open && (
-          <div className="absolute top-0 right-full mr-2 z-50 bg-white rounded-xl border border-sky-700/30 p-6 flex flex-col gap-4 shadow-md w-72">
+          <div className="absolute top-0 right-full mr-2 z-50 bg-white dark:bg-[#323235] rounded-xl border border-sky-700/30 dark:border-blue-300/50 p-6 flex flex-col gap-4 shadow-md w-72">
             {inputs}
           </div>
         )

--- a/apps/next/src/components/ui/onboarding.tsx
+++ b/apps/next/src/components/ui/onboarding.tsx
@@ -61,13 +61,13 @@ const WelcomeView = React.forwardRef<HTMLDivElement>((_, ref) => {
           variant="h4"
           fontWeight={700}
           fontFamily="Poppins, sans-serif"
-          className="text-sky-700"
+          className="text-sky-700 dark:text-blue-300"
         >
           PeterPlate
         </Typography>
         <Typography
           fontFamily="Poppins, sans-serif"
-          color="gray"
+          color="text.secondary"
           fontWeight={500}
           fontSize={18}
           pt="10px"
@@ -77,7 +77,7 @@ const WelcomeView = React.forwardRef<HTMLDivElement>((_, ref) => {
         <Typography
           variant="h5"
           fontFamily="Poppins, sans-serif"
-          color="black"
+          color="text.primary"
           fontWeight={700}
           pt="20px"
         >
@@ -85,7 +85,7 @@ const WelcomeView = React.forwardRef<HTMLDivElement>((_, ref) => {
         </Typography>
         <Typography
           fontFamily="Poppins, sans-serif"
-          color="gray"
+          color="text.secondary"
           fontWeight={500}
           fontSize={15}
           pt="10px"
@@ -97,7 +97,7 @@ const WelcomeView = React.forwardRef<HTMLDivElement>((_, ref) => {
         <GoogleSignInButton />
         <Typography
           fontFamily="Poppins, sans-serif"
-          color="gray"
+          color="text.secondary"
           fontWeight={500}
           fontSize={13}
           py="10px"
@@ -122,7 +122,7 @@ const PersonalizeView = React.forwardRef<HTMLDivElement, PersonalizeViewProps>(
           sx={{
             py: "20px",
           }}
-          className="bg-sky-700"
+          className="bg-sky-700 dark:bg-[#323235]"
         >
           <Avatar
             src="/peterplate-icon.webp"
@@ -135,8 +135,11 @@ const PersonalizeView = React.forwardRef<HTMLDivElement, PersonalizeViewProps>(
           <Typography
             variant="h5"
             fontFamily="Poppins, sans-serif"
-            color="white"
             fontWeight={700}
+            sx={{
+              color: "white",
+              ".dark &": { color: "var(--mui-palette-primary-main)" },
+            }}
           >
             Welcome, {name}!
           </Typography>
@@ -145,18 +148,22 @@ const PersonalizeView = React.forwardRef<HTMLDivElement, PersonalizeViewProps>(
           </Typography>
         </Box>
 
-        <Box px="40px" pt="20px">
+        <Box
+          px="40px"
+          pt="20px"
+          sx={{ borderTop: "3px solid", borderColor: "divider" }}
+        >
           <Typography
             variant="h5"
             fontFamily="Poppins, sans-serif"
             fontWeight={700}
-            className="text-sky-700"
+            className="text-sky-700 dark:text-blue-300"
           >
             {title}
           </Typography>
           <Typography
             fontFamily="Poppins, sans-serif"
-            color="gray"
+            color="text.primary"
             fontSize={16}
             pt="16px"
           >
@@ -193,14 +200,16 @@ const PersonalizeView = React.forwardRef<HTMLDivElement, PersonalizeViewProps>(
               sx={{
                 py: 3,
                 textTransform: "none",
-                color: "black",
+                color: "var(--mui-palette-text-primary)",
                 height: "40px",
                 "&.Mui-selected": {
-                  backgroundColor: "rgba(0, 105, 168, .2)",
-                  color: "#0069A8",
-                  borderColor: "#0069A8 !important",
+                  backgroundColor:
+                    "color-mix(in srgb, var(--mui-palette-primary-main) 20%, transparent)",
+                  color: "var(--mui-palette-primary-main)",
+                  borderColor: "var(--mui-palette-primary-main) !important",
                   "&:hover": {
-                    backgroundColor: "rgba(0, 105, 168, .4)",
+                    backgroundColor:
+                      "color-mix(in srgb, var(--mui-palette-primary-main) 35%, transparent)",
                   },
                 },
               }}
@@ -325,7 +334,11 @@ const OnboardingContent = React.forwardRef<
         steps={3}
         position="static"
         activeStep={activeStep}
-        sx={{ px: "40px" }}
+        sx={{
+          px: "40px",
+          backgroundColor: "transparent",
+          backgroundImage: "none",
+        }}
         nextButton={
           activeStep === 2 ? (
             <Button
@@ -339,6 +352,14 @@ const OnboardingContent = React.forwardRef<
                 bgcolor: "#0069A8",
                 "&:hover": {
                   filter: "brightness(0.85)",
+                },
+                ".dark &": {
+                  bgcolor: "#93C5FD",
+                  color: "#111827",
+                },
+                ".dark &.Mui-disabled": {
+                  backgroundColor: "#3F3F47",
+                  color: "#71717A",
                 },
               }}
             >
@@ -356,6 +377,14 @@ const OnboardingContent = React.forwardRef<
                 bgcolor: "#0069A8",
                 "&:hover": {
                   filter: "brightness(0.85)",
+                },
+                ".dark &": {
+                  bgcolor: "#93C5FD",
+                  color: "#111827",
+                },
+                ".dark &.Mui-disabled": {
+                  backgroundColor: "#3F3F47",
+                  color: "#71717A",
                 },
               }}
             >
@@ -375,6 +404,14 @@ const OnboardingContent = React.forwardRef<
               bgcolor: "#0069A8",
               "&:hover": {
                 filter: "brightness(0.85)",
+              },
+              ".dark &": {
+                bgcolor: "#93C5FD",
+                color: "#111827",
+              },
+              ".dark &.Mui-disabled": {
+                backgroundColor: "#3F3F47",
+                color: "#71717A",
               },
             }}
           >
@@ -412,6 +449,12 @@ export default function OnboardingDialog(): React.JSX.Element {
               padding: 0,
               overflow: "hidden",
               borderRadius: "16px",
+              ".dark &": {
+                border: "3px solid",
+                borderColor: "var(--mui-palette-divider)",
+                backgroundImage: "none",
+                backgroundColor: "#303035",
+              },
             },
           },
         }}
@@ -440,6 +483,10 @@ export default function OnboardingDialog(): React.JSX.Element {
             borderTopRightRadius: "10px",
             marginTop: "96px",
             height: "auto",
+          },
+          ".dark & .MuiDrawer-paper": {
+            backgroundImage: "none",
+            backgroundColor: "#303035",
           },
         }}
       >

--- a/apps/next/src/components/ui/restaurant/dishes-view.tsx
+++ b/apps/next/src/components/ui/restaurant/dishes-view.tsx
@@ -1,3 +1,4 @@
+import { Typography } from "@mui/material";
 import type { RestaurantInfo } from "@peterplate/api";
 import { useMemo } from "react";
 import DishesInfo from "@/components/ui/dishes-info";
@@ -113,10 +114,15 @@ export function DishesView({
               id={station.name.toLowerCase()}
               className="[&_#food-scroll]:h-auto [&_#food-scroll]:overflow-y-visible mb-8 scroll-mt-4"
             >
-              <div className="border-b-2 mb-4">
-                <h1 className="font-bold text-3xl">
+              <div className="mb-4">
+                <Typography
+                  variant="h5"
+                  fontWeight={700}
+                  color="text.primary"
+                  sx={{ fontSize: "1.875rem" }}
+                >
                   {toTitleCase(station.name)}
-                </h1>
+                </Typography>
               </div>
               <DishesInfo
                 dishes={getFilteredDishes(station.dishes)}
@@ -130,10 +136,15 @@ export function DishesView({
         : // Normal View: Render active station logic
           activeStation && (
             <div className="[&_#food-scroll]:h-auto [&_#food-scroll]:overflow-y-visible">
-              <div className="border-b-2 mb-4">
-                <h1 className="font-bold text-3xl">
+              <div className="mb-4">
+                <Typography
+                  variant="h5"
+                  fontWeight={700}
+                  color="text.primary"
+                  sx={{ fontSize: "1.875rem" }}
+                >
                   {toTitleCase(activeStation.name)}
-                </h1>
+                </Typography>
               </div>
               <DishesInfo
                 dishes={getFilteredDishes(enrichedActiveStation?.dishes ?? [])}

--- a/apps/next/src/components/ui/restaurant/header/desktop-tabs.tsx
+++ b/apps/next/src/components/ui/restaurant/header/desktop-tabs.tsx
@@ -54,7 +54,7 @@ export function DesktopTabs({
               key={station.name}
               value={station.name.toLowerCase()}
               label={toTitleCase(station.name)}
-              className="!rounded !border !border-transparent !bg-transparent !px-4 !py-1.5 !text-sm !font-medium !text-slate-700 dark:!text-white !normal-case !min-h-0 aria-selected:!bg-white dark:aria-selected:!bg-white aria-selected:!text-slate-900 dark:aria-selected:!text-gray-900 aria-selected:!border-slate-200 dark:aria-selected:!border-slate-200 aria-selected:!shadow-sm"
+              className="!rounded !border !border-transparent !bg-transparent !px-4 !py-1.5 !text-sm !font-medium !text-black dark:!text-white !normal-case !min-h-0 aria-selected:!bg-white dark:aria-selected:!bg-white aria-selected:!text-slate-900 dark:aria-selected:!text-gray-900 aria-selected:!border-slate-200 dark:aria-selected:!border-slate-200 aria-selected:!shadow-sm"
             />
           ))}
         </Tabs>

--- a/apps/next/src/components/ui/restaurant/header/desktop-tabs.tsx
+++ b/apps/next/src/components/ui/restaurant/header/desktop-tabs.tsx
@@ -45,7 +45,7 @@ export function DesktopTabs({
               setSelectedStation(val);
             }
           }}
-          className="flex w-full overflow-x-auto no-scrollbar !bg-sky-700/40 !rounded-lg !p-2 [&_.MuiTabs-flexContainer]:justify-between [&_.MuiTabs-flexContainer]:gap-2 [&_.MuiTabs-indicator]:hidden"
+          className="flex w-full overflow-x-auto no-scrollbar !bg-sky-700/40 dark:!bg-[#46566a] !rounded-lg !p-2 [&_.MuiTabs-flexContainer]:justify-between [&_.MuiTabs-flexContainer]:gap-2 [&_.MuiTabs-indicator]:hidden"
           variant="scrollable"
           scrollButtons={false}
         >
@@ -54,7 +54,7 @@ export function DesktopTabs({
               key={station.name}
               value={station.name.toLowerCase()}
               label={toTitleCase(station.name)}
-              className="!rounded !border !border-transparent !bg-transparent !px-4 !py-1.5 !text-sm !font-medium !text-slate-700 !normal-case !min-h-0 aria-selected:!bg-white aria-selected:!text-slate-900 aria-selected:!border-slate-200 aria-selected:!shadow-sm"
+              className="!rounded !border !border-transparent !bg-transparent !px-4 !py-1.5 !text-sm !font-medium !text-slate-700 dark:!text-white !normal-case !min-h-0 aria-selected:!bg-white dark:aria-selected:!bg-white aria-selected:!text-slate-900 dark:aria-selected:!text-gray-900 aria-selected:!border-slate-200 dark:aria-selected:!border-slate-200 aria-selected:!shadow-sm"
             />
           ))}
         </Tabs>
@@ -67,7 +67,7 @@ export function DesktopTabs({
             size="small"
             type="button"
             onClick={() => setIsCompactView(false)}
-            className={`!border-sky-700 !normal-case ${!isCompactView ? "!bg-sky-700 !text-white hover:!bg-sky-700" : "!bg-white !text-sky-700 hover:!bg-sky-50"}`}
+            className={`!border-sky-700 dark:!border-blue-300 !normal-case ${!isCompactView ? "!bg-sky-700 !text-white hover:!bg-sky-700 dark:!bg-blue-300 dark:!text-gray-900" : "!bg-white !text-sky-700 hover:!bg-sky-50 dark:!bg-transparent dark:!text-white"}`}
             startIcon={<MenuIcon className="h-4 w-4" />}
           >
             Card View
@@ -77,7 +77,7 @@ export function DesktopTabs({
             size="small"
             type="button"
             onClick={() => setIsCompactView(true)}
-            className={`!border-sky-700 !normal-case ${isCompactView ? "!bg-sky-700 !text-white hover:!bg-sky-700" : "!bg-white !text-sky-700 hover:!bg-sky-50"}`}
+            className={`!border-sky-700 dark:!border-blue-300 !normal-case ${isCompactView ? "!bg-sky-700 !text-white hover:!bg-sky-700 dark:!bg-blue-300 dark:!text-gray-900" : "!bg-white !text-sky-700 hover:!bg-sky-50 dark:!bg-transparent dark:!text-white"}`}
             startIcon={<GridView className="h-4 w-4" />}
           >
             Compact View

--- a/apps/next/src/components/ui/restaurant/header/mobile-actions.tsx
+++ b/apps/next/src/components/ui/restaurant/header/mobile-actions.tsx
@@ -58,7 +58,7 @@ export function MobileActions({
           <>
             <Button
               variant="outlined"
-              className="!flex-[1] !h-8 !px-1 text-xs !border-sky-700 !text-black hover:bg-sky-100 !flex-nowrap !items-center"
+              className="!flex-[1] !h-8 !px-1 text-xs !border-sky-700 dark:!border-blue-300 !text-black dark:!text-white hover:bg-sky-100 dark:hover:!bg-zinc-700 !flex-nowrap !items-center"
               type="button"
               onClick={(e) => setMenuAnchor(e.currentTarget)}
             >
@@ -79,7 +79,9 @@ export function MobileActions({
               }}
               slotProps={{
                 paper: {
-                  className: "w-[200px] p-2 mt-1",
+                  className:
+                    "w-[200px] p-2 mt-1 border border-sky-700 dark:!bg-[#323235] dark:!border-blue-300",
+                  sx: { backgroundImage: "none" },
                 },
               }}
             >
@@ -88,7 +90,7 @@ export function MobileActions({
                   <button
                     type="button"
                     key={station.name}
-                    className="text-left px-2 py-1.5 text-sm font-medium rounded-sm hover:bg-slate-100 transition-colors"
+                    className="text-left px-2 py-1.5 text-sm font-medium rounded-sm hover:bg-slate-100 dark:text-white dark:hover:bg-[#434e5d] transition-colors"
                     onClick={() => {
                       const val = station.name.toLowerCase();
                       if (isCompactView) {
@@ -117,7 +119,7 @@ export function MobileActions({
           <>
             <Button
               variant="outlined"
-              className="!flex-[1.5] !h-8 !px-1 text-xs !border-sky-700 !text-black hover:bg-sky-100 !flex-nowrap !items-center"
+              className="!flex-[1.5] !h-8 !px-1 text-xs !border-sky-700 dark:!border-blue-300 !text-black dark:!text-white hover:bg-sky-100 dark:hover:!bg-zinc-700 !flex-nowrap !items-center"
               type="button"
               onClick={(e) => setScheduleAnchor(e.currentTarget)}
             >
@@ -141,7 +143,9 @@ export function MobileActions({
               }}
               slotProps={{
                 paper: {
-                  className: "w-[300px] p-0 mt-1",
+                  className:
+                    "w-[300px] p-0 mt-1 border border-sky-700 dark:!bg-[#323235] dark:!border-blue-300",
+                  sx: { backgroundImage: "none" },
                 },
               }}
             >
@@ -149,6 +153,7 @@ export function MobileActions({
                 <Typography
                   variant="subtitle1"
                   fontWeight={700}
+                  color="primary"
                   className="mb-2"
                 >
                   Special Schedules
@@ -168,12 +173,21 @@ export function MobileActions({
                         key={`${event.title}-${String(event.start)}-${event.restaurantId}`}
                         disableGutters
                         elevation={0}
-                        className="before:hidden border-b last:border-b-0"
+                        className="before:hidden border-b dark:border-blue-300/30 last:border-b-0 dark:bg-transparent"
                       >
-                        <AccordionSummary expandIcon={<ExpandMore />}>
+                        <AccordionSummary
+                          expandIcon={
+                            <ExpandMore className="dark:text-blue-300" />
+                          }
+                          className="dark:!bg-transparent"
+                        >
                           <div className="flex flex-col w-full pr-2 text-left">
                             <div className="flex justify-between items-center w-full">
-                              <Typography variant="body2" fontWeight={700}>
+                              <Typography
+                                variant="body2"
+                                fontWeight={700}
+                                color="primary"
+                              >
                                 {event.title}
                               </Typography>
                               {isActive && (
@@ -224,13 +238,13 @@ export function MobileActions({
           >
             <ToggleButton
               value="card"
-              className="!border-sky-700 !px-2 !min-w-0 aria-pressed:!bg-sky-700 aria-pressed:!text-white !bg-white !text-sky-700"
+              className="!border-sky-700 dark:!border-blue-300 !px-2 !min-w-0 aria-pressed:!bg-sky-700 dark:aria-pressed:!bg-blue-300 aria-pressed:!text-white dark:aria-pressed:!text-gray-900 !bg-white dark:!bg-transparent !text-sky-700 dark:!text-blue-300"
             >
               <MenuIcon className="h-4 w-4" />
             </ToggleButton>
             <ToggleButton
               value="compact"
-              className="!border-sky-700 !px-2 !min-w-0 aria-pressed:!bg-sky-700 aria-pressed:!text-white !bg-white !text-sky-700"
+              className="!border-sky-700 dark:!border-blue-300 !px-2 !min-w-0 aria-pressed:!bg-sky-700 dark:aria-pressed:!bg-blue-300 aria-pressed:!text-white dark:aria-pressed:!text-gray-900 !bg-white dark:!bg-transparent !text-sky-700 dark:!text-blue-300"
             >
               <GridView className="h-4 w-4" />
             </ToggleButton>

--- a/apps/next/src/components/ui/restaurant/header/restaurant-filters.tsx
+++ b/apps/next/src/components/ui/restaurant/header/restaurant-filters.tsx
@@ -1,5 +1,11 @@
 import { ArrowDropDownRounded } from "@mui/icons-material";
-import { FormControl, InputLabel, MenuItem, Select } from "@mui/material";
+import {
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Typography,
+} from "@mui/material";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
@@ -44,7 +50,7 @@ export function RestaurantFilters({
         <FormControl fullWidth size="small" variant="outlined">
           <InputLabel
             id="meal-select-label"
-            className="!text-sky-700 [&.Mui-focused]:!text-sky-700"
+            className="!text-sky-700 dark:!text-blue-300 [&.Mui-focused]:!text-sky-700 dark:[&.Mui-focused]:!text-blue-300"
           >
             Meal
           </InputLabel>
@@ -54,7 +60,7 @@ export function RestaurantFilters({
             label="Meal"
             onChange={(e) => setSelectedPeriod(e.target.value)}
             IconComponent={ArrowDropDownRounded}
-            className="bg-white [&_fieldset]:!border-sky-700 [&:hover_fieldset]:!border-sky-700 [&_.Mui-focused_fieldset]:!border-sky-700 [&_.MuiSvgIcon-root]:!text-sky-700"
+            className="bg-white dark:bg-[#323235] [&_fieldset]:!border-sky-700 dark:[&_fieldset]:!border-blue-300 [&:hover_fieldset]:!border-sky-700 dark:[&:hover_fieldset]:!border-blue-300 [&_.Mui-focused_fieldset]:!border-sky-700 dark:[&_.Mui-focused_fieldset]:!border-blue-300 [&_.MuiSvgIcon-root]:!text-sky-700 dark:[&_.MuiSvgIcon-root]:!text-blue-300"
             MenuProps={{
               anchorOrigin: {
                 vertical: "bottom",
@@ -95,10 +101,15 @@ export function RestaurantFilters({
                   <MenuItem
                     key={time}
                     value={mealTimeKey}
-                    className="!flex !justify-between !items-center !gap-4"
+                    className="!flex !justify-between !items-center !gap-4 [&.Mui-selected]:!bg-sky-700 [&.Mui-selected]:!text-white [&:hover]:!bg-sky-50 dark:[&.Mui-selected]:!bg-blue-300 dark:[&.Mui-selected]:!text-gray-900 dark:[&:hover]:!bg-[#434e5d]"
                   >
                     <span>{toTitleCase(time)}</span>
-                    <span className="text-gray-500 text-sm">{timeString}</span>
+                    <Typography
+                      variant="caption"
+                      className="text-gray-500 [.Mui-selected_&]:!text-white dark:text-zinc-400 dark:[.Mui-selected_&]:!text-gray-900"
+                    >
+                      {timeString}
+                    </Typography>
                   </MenuItem>
                 );
               })
@@ -130,17 +141,17 @@ export function RestaurantFilters({
                   fullWidth: true,
                   onClick: () => setIsDatePickerOpen(true),
                   InputLabelProps: {
-                    className: "!text-sky-700",
+                    className: "!text-sky-700 dark:!text-blue-300",
                   },
                   inputProps: {
                     readOnly: true,
                     className: "!cursor-pointer",
                   },
                   className:
-                    "bg-white [&_fieldset]:!border-sky-700 [&:hover_fieldset]:!border-sky-700 [&_.Mui-focused_fieldset]:!border-sky-700 [&_.MuiSvgIcon-root]:!text-sky-700 !cursor-pointer",
+                    "bg-white dark:bg-[#323235] [&_fieldset]:!border-sky-700 dark:[&_fieldset]:!border-blue-300 [&:hover_fieldset]:!border-sky-700 dark:[&:hover_fieldset]:!border-blue-300 [&_.Mui-focused_fieldset]:!border-sky-700 dark:[&_.Mui-focused_fieldset]:!border-blue-300 [&_.MuiSvgIcon-root]:!text-sky-700 dark:[&_.MuiSvgIcon-root]:!text-blue-300 !cursor-pointer",
                 },
                 openPickerIcon: {
-                  className: "!text-sky-700",
+                  className: "!text-sky-700 dark:!text-blue-300",
                 },
                 dialog: {
                   disableScrollLock: true,

--- a/apps/next/src/components/ui/restaurant/header/restaurant-filters.tsx
+++ b/apps/next/src/components/ui/restaurant/header/restaurant-filters.tsx
@@ -196,8 +196,8 @@ export function RestaurantFilters({
             h-[40px] rounded-md border text-sm font-medium transition-all duration-200
             ${
               showPreferencesOnly
-                ? "bg-sky-700 text-white border-sky-700 shadow-md"
-                : "bg-white text-sky-700 border-sky-700 hover:bg-sky-50"
+                ? "bg-sky-700 text-white border-sky-700 shadow-md dark:bg-blue-300 dark:text-gray-900 dark:border-blue-300"
+                : "bg-white text-sky-700 border-sky-700 hover:bg-sky-50 dark:bg-[#323235] dark:text-blue-300 dark:border-blue-300 dark:hover:bg-zinc-700"
             }
           `}
         >

--- a/apps/next/src/components/ui/restaurant/header/restaurant-filters.tsx
+++ b/apps/next/src/components/ui/restaurant/header/restaurant-filters.tsx
@@ -10,6 +10,7 @@ import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import type { DateList } from "@peterplate/db";
+import { useTheme } from "next-themes";
 import type { CalendarRange } from "@/components/ui/toolbar";
 import { formatOpenCloseTime, isSameDay, toTitleCase } from "@/utils/funcs";
 
@@ -44,6 +45,7 @@ export function RestaurantFilters({
   showPreferencesOnly,
   setShowPreferencesOnly,
 }: RestaurantFiltersProps) {
+  const { resolvedTheme } = useTheme();
   return (
     <div className={isDesktop ? "flex gap-2" : "grid grid-cols-2 gap-2 w-full"}>
       <div className={isDesktop ? "w-52" : "w-full"}>
@@ -60,7 +62,7 @@ export function RestaurantFilters({
             label="Meal"
             onChange={(e) => setSelectedPeriod(e.target.value)}
             IconComponent={ArrowDropDownRounded}
-            className="bg-white dark:bg-[#323235] [&_fieldset]:!border-sky-700 dark:[&_fieldset]:!border-blue-300 [&:hover_fieldset]:!border-sky-700 dark:[&:hover_fieldset]:!border-blue-300 [&_.Mui-focused_fieldset]:!border-sky-700 dark:[&_.Mui-focused_fieldset]:!border-blue-300 [&_.MuiSvgIcon-root]:!text-sky-700 dark:[&_.MuiSvgIcon-root]:!text-blue-300"
+            className="bg-white dark:bg-[#27272A] [&_fieldset]:!border-sky-700 dark:[&_fieldset]:!border-blue-300 [&:hover_fieldset]:!border-sky-700 dark:[&:hover_fieldset]:!border-blue-300 [&_.Mui-focused_fieldset]:!border-sky-700 dark:[&_.Mui-focused_fieldset]:!border-blue-300 [&_.MuiSvgIcon-root]:!text-sky-700 dark:[&_.MuiSvgIcon-root]:!text-blue-300"
             MenuProps={{
               anchorOrigin: {
                 vertical: "bottom",
@@ -74,6 +76,11 @@ export function RestaurantFilters({
               PaperProps: {
                 style: {
                   minWidth: "280px",
+                  backgroundImage: "none",
+                  backgroundColor:
+                    resolvedTheme === "dark" ? "#323235" : undefined,
+                  border: "1px solid",
+                  borderColor: resolvedTheme === "dark" ? "#93C5FD" : "#0369a1",
                 },
               },
             }}
@@ -148,7 +155,7 @@ export function RestaurantFilters({
                     className: "!cursor-pointer",
                   },
                   className:
-                    "bg-white dark:bg-[#323235] [&_fieldset]:!border-sky-700 dark:[&_fieldset]:!border-blue-300 [&:hover_fieldset]:!border-sky-700 dark:[&:hover_fieldset]:!border-blue-300 [&_.Mui-focused_fieldset]:!border-sky-700 dark:[&_.Mui-focused_fieldset]:!border-blue-300 [&_.MuiSvgIcon-root]:!text-sky-700 dark:[&_.MuiSvgIcon-root]:!text-blue-300 !cursor-pointer",
+                    "bg-white dark:bg-[#27272A] [&_fieldset]:!border-sky-700 dark:[&_fieldset]:!border-blue-300 [&:hover_fieldset]:!border-sky-700 dark:[&:hover_fieldset]:!border-blue-300 [&_.Mui-focused_fieldset]:!border-sky-700 dark:[&_.Mui-focused_fieldset]:!border-blue-300 [&_.MuiSvgIcon-root]:!text-sky-700 dark:[&_.MuiSvgIcon-root]:!text-blue-300 !cursor-pointer",
                 },
                 openPickerIcon: {
                   className: "!text-sky-700 dark:!text-blue-300",
@@ -158,7 +165,8 @@ export function RestaurantFilters({
                 },
                 popper: {
                   placement: "bottom-end",
-                  className: "[&_.MuiPaper-root]:mt-1",
+                  className:
+                    "[&_.MuiPaper-root]:mt-1 [&_.MuiPaper-root]:!border [&_.MuiPaper-root]:!border-sky-700 dark:[&_.MuiPaper-root]:!bg-[#323235] dark:[&_.MuiPaper-root]:!border-blue-300 dark:[&_.MuiPaper-root]:![background-image:none]",
                   modifiers: [
                     {
                       name: "flip",
@@ -197,7 +205,7 @@ export function RestaurantFilters({
             ${
               showPreferencesOnly
                 ? "bg-sky-700 text-white border-sky-700 shadow-md dark:bg-blue-300 dark:text-gray-900 dark:border-blue-300"
-                : "bg-white text-sky-700 border-sky-700 hover:bg-sky-50 dark:bg-[#323235] dark:text-blue-300 dark:border-blue-300 dark:hover:bg-zinc-700"
+                : "bg-white text-sky-700 border-sky-700 hover:bg-sky-50 dark:bg-[#27272A] dark:text-blue-300 dark:border-blue-300 dark:hover:bg-zinc-700"
             }
           `}
         >

--- a/apps/next/src/components/ui/restaurant/header/restaurant-header.tsx
+++ b/apps/next/src/components/ui/restaurant/header/restaurant-header.tsx
@@ -11,7 +11,7 @@ export function RestaurantHeader({ isDesktop, hall }: RestaurantHeaderProps) {
 
   return (
     // Desktop title
-    <Typography variant="h4" fontWeight={700} className="text-sky-700">
+    <Typography variant="h4" fontWeight={700} color="primary">
       {hall === HallEnum.ANTEATERY ? "Anteatery" : "Brandywine"}
     </Typography>
   );

--- a/apps/next/src/components/ui/restaurant/restaurant-page.tsx
+++ b/apps/next/src/components/ui/restaurant/restaurant-page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { LocationOn } from "@mui/icons-material";
-import { Container, Link, Typography } from "@mui/material";
+import { Box, Container, Link, Typography } from "@mui/material";
 import type { RestaurantInfo } from "@peterplate/api";
 import type { DateList } from "@peterplate/db";
 import Image from "next/image";
@@ -190,7 +190,7 @@ export function RestaurantPage({
   const displayDate = selectedDate ?? today;
 
   return (
-    <div>
+    <Box sx={{ bgcolor: "background.default", minHeight: "100vh" }}>
       {/* Hero image & mobile header */}
       <div className="relative w-full h-[200px] md:h-[250px]">
         <Image
@@ -312,7 +312,7 @@ export function RestaurantPage({
           )}
         </div>
       </Container>
-    </div>
+    </Box>
   );
 }
 

--- a/apps/next/src/components/ui/restaurant/sidebar.tsx
+++ b/apps/next/src/components/ui/restaurant/sidebar.tsx
@@ -35,11 +35,15 @@ export function Sidebar({
   return (
     <div className="w-full md:basis-[325px] md:max-w-[325px] md:min-h-[740px]">
       {/* Hours of operation card */}
-      <Paper elevation={1} className="mb-4 overflow-hidden">
-        <div className="bg-sky-500/20 px-4 py-3 border-b-2 border-sky-700">
+      <Paper
+        elevation={0}
+        className="mb-4 overflow-hidden dark:bg-[#303035]"
+        sx={{ border: 1, borderColor: "divider" }}
+      >
+        <div className="bg-sky-500/20 dark:bg-blue-300/10 px-4 py-3 border-b-2 border-sky-700 dark:border-blue-300">
           <Typography
             variant="h6"
-            className="!text-sky-700 !font-bold !text-center"
+            className="!font-bold !text-center !text-sky-700 dark:!text-blue-300"
           >
             Hours of Operation
           </Typography>
@@ -92,11 +96,15 @@ export function Sidebar({
       </Paper>
 
       {/* Location card */}
-      <Paper elevation={1} className="mb-4 overflow-hidden">
-        <div className="bg-sky-500/20 px-4 py-3 border-b-2 border-sky-600">
+      <Paper
+        elevation={0}
+        className="mb-4 overflow-hidden dark:bg-[#303035]"
+        sx={{ border: 1, borderColor: "divider" }}
+      >
+        <div className="bg-sky-500/20 dark:bg-blue-300/10 px-4 py-3 border-b-2 border-sky-600 dark:border-blue-300">
           <Typography
             variant="h6"
-            className="!text-sky-700 !font-bold !text-center"
+            className="!font-bold !text-center !text-sky-700 dark:!text-blue-300"
           >
             Location
           </Typography>
@@ -140,11 +148,15 @@ export function Sidebar({
       </Paper>
 
       {/* Special Schedules card */}
-      <Paper elevation={1} className="overflow-hidden">
-        <div className="bg-sky-500/20 px-4 py-3 border-b-2 border-sky-600">
+      <Paper
+        elevation={0}
+        className="overflow-hidden dark:bg-[#303035]"
+        sx={{ border: 1, borderColor: "divider" }}
+      >
+        <div className="bg-sky-500/20 dark:bg-blue-300/10 px-4 py-3 border-b-2 border-sky-600 dark:border-blue-300">
           <Typography
             variant="h6"
-            className="!text-sky-700 !font-bold !text-center"
+            className="!font-bold !text-center !text-sky-700 dark:!text-blue-300"
           >
             Special Schedules
           </Typography>
@@ -173,17 +185,19 @@ export function Sidebar({
                 return (
                   <Accordion
                     key={`${event.title}-${String(event.start)}-${event.restaurantId}`}
-                    className="!border !border-sky-200 !rounded-lg !shadow-none before:!hidden"
+                    className="!border !border-sky-200 dark:!border-blue-300/30 !rounded-lg !shadow-none before:!hidden dark:!bg-transparent"
                   >
                     <AccordionSummary
-                      expandIcon={<ExpandMore className="!text-sky-600" />}
-                      className="!min-h-0 !py-2"
+                      expandIcon={
+                        <ExpandMore className="!text-sky-600 dark:!text-blue-300" />
+                      }
+                      className="!min-h-0 !py-2 dark:!bg-transparent"
                     >
                       <div className="flex flex-col w-full pr-2">
                         <div className="flex justify-between items-center w-full gap-2">
                           <Typography
                             variant="body2"
-                            className="!text-sky-700 !font-semibold"
+                            className="!text-sky-700 dark:!text-blue-300 !font-semibold"
                           >
                             {event.title}
                           </Typography>
@@ -191,7 +205,7 @@ export function Sidebar({
                             <Chip
                               label="ACTIVE"
                               size="small"
-                              className="!h-5 !text-[0.65rem] !font-bold !bg-sky-600 !text-white !rounded-full"
+                              className="!h-5 !text-[0.65rem] !font-bold !bg-sky-600 dark:!bg-blue-300 dark:!text-gray-900 !text-white !rounded-full"
                             />
                           )}
                         </div>

--- a/apps/next/src/components/ui/sidebar/sidebar-content.tsx
+++ b/apps/next/src/components/ui/sidebar/sidebar-content.tsx
@@ -10,11 +10,12 @@ import {
   LightMode as LightModeIcon,
   Logout as LogoutIcon,
 } from "@mui/icons-material";
-import { Tooltip } from "@mui/material";
+import { Box, Tooltip, Typography } from "@mui/material";
 import Image from "next/image";
 import Link from "next/link";
-import { useTheme } from "next-themes";
 import type { ReactNode } from "react";
+import { useTheme } from "next-themes";
+import type React from "react";
 import { useEffect, useState } from "react";
 import { GoogleSignInButton } from "@/components/auth/google-sign-in";
 import { signOut, useSession } from "@/utils/auth-client";
@@ -28,7 +29,7 @@ interface ProfileMenuContentProps {
 export default function SidebarContent({
   onClose,
   onEditPreferencesClick,
-}: ProfileMenuContentProps) {
+}: ProfileMenuContentProps): React.JSX.Element | null {
   const { data: session } = useSession();
   const user = session?.user;
   const userId = user?.id;
@@ -55,7 +56,10 @@ export default function SidebarContent({
   };
 
   return (
-    <div className="w-full h-full rounded-2xl bg-white dark:bg-gray-900 shadow-xl flex flex-col">
+    <Box
+      className="w-full h-full rounded-2xl bg-white dark:bg-[#323235] shadow-xl flex flex-col"
+      sx={{ border: 1, borderColor: "divider" }}
+    >
       {/* Header */}
       <div className="flex items-start justify-between px-5 pt-5">
         <div className="flex items-center gap-3">
@@ -67,21 +71,21 @@ export default function SidebarContent({
             className="rounded-full object-cover"
           />
           <div>
-            <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
+            <Typography variant="body2" fontWeight={600} color="text.primary">
               {user?.name || "Peter Anteater"}
-            </h2>
-            <p className="text-xs text-gray-500 dark:text-gray-400">
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
               {user?.email || "panteater@uci.edu"}
-            </p>
+            </Typography>
           </div>
         </div>
 
         <button
           type="button"
           onClick={onClose}
-          className="rounded-full p-1.5 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800"
+          className="rounded-full p-1.5 hover:bg-gray-100 dark:hover:bg-gray-700"
         >
-          <CloseIcon fontSize="small" />
+          <CloseIcon sx={{ fontSize: 18, color: "text.primary" }} />
         </button>
       </div>
 
@@ -89,20 +93,26 @@ export default function SidebarContent({
       <div className="flex-1 px-5 pt-4 space-y-5">
         {/* Dietary Preferences */}
         <div>
-          <h3 className="text-sm font-semibold text-blue-600 dark:text-blue-400 mb-2">
+          <Typography variant="body2" fontWeight={600} color="primary" mb={1}>
             Dietary Preferences
-          </h3>
+          </Typography>
 
-          <p className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+          <Typography
+            variant="caption"
+            fontWeight={600}
+            color="text.secondary"
+            display="block"
+            mb={0.5}
+          >
             Restrictions:
-          </p>
+          </Typography>
 
           <div className="flex flex-wrap gap-1.5 mb-3">
             {preferences?.length ? (
               preferences.map((pref) => (
                 <span
                   key={pref}
-                  className="rounded-md border border-blue-500 px-2.5 py-0.5 text-xs text-blue-600 dark:text-blue-400"
+                  className="rounded-md border border-sky-700 bg-sky-100 px-2.5 py-0.5 text-xs text-sky-700 dark:border-blue-300 dark:text-blue-300 dark:bg-blue-300/20"
                 >
                   {pref}
                 </span>
@@ -112,15 +122,21 @@ export default function SidebarContent({
             )}
           </div>
 
-          <p className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+          <Typography
+            variant="caption"
+            fontWeight={600}
+            color="text.secondary"
+            display="block"
+            mb={0.5}
+          >
             Allergies:
-          </p>
+          </Typography>
           <div className="flex flex-wrap gap-1.5">
             {allergies?.length ? (
               allergies.map((allergy) => (
                 <span
                   key={allergy}
-                  className="rounded-md border border-blue-500 px-2.5 py-0.5 text-xs text-blue-600 dark:text-blue-400"
+                  className="rounded-md border border-sky-700 bg-sky-100 px-2.5 py-0.5 text-xs text-sky-700 dark:border-blue-300 dark:text-blue-300 dark:bg-blue-300/20"
                 >
                   {allergy}
                 </span>
@@ -133,11 +149,11 @@ export default function SidebarContent({
 
         {/* Appearance */}
         <div>
-          <h3 className="text-sm font-semibold text-blue-600 dark:text-blue-400 mb-2">
+          <Typography variant="body2" fontWeight={600} color="primary" mb={1}>
             Appearance
-          </h3>
+          </Typography>
 
-          <div className="flex rounded-lg border border-blue-500 overflow-hidden">
+          <div className="flex rounded-lg border border-sky-700 dark:border-blue-300 overflow-hidden">
             <ThemeButton
               active={theme === "light"}
               onClick={() => setTheme("light")}
@@ -172,8 +188,8 @@ export default function SidebarContent({
                 }}
                 className="w-full flex items-center gap-3 rounded-lg px-4 py-2 text-sm text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:dark:hover:bg-transparent"
               >
-                <EditIcon fontSize="small" />
-                <span className="font-semibold">Edit Preferences</span>
+                <Box sx={{ color: "primary.main" }}><EditIcon fontSize="small" /></Box>
+                <Typography variant="body2" fontWeight={500} color="text.primary">Edit Preferences</Typography>
               </button>
             </span>
           </Tooltip>
@@ -203,9 +219,7 @@ export default function SidebarContent({
           <button
             type="button"
             onClick={handleSignOut}
-            className="w-full rounded-lg bg-blue-600
-            py-2.5 text-sm font-semibold text-white
-            hover:bg-blue-700 flex items-center justify-center"
+            className="w-full rounded-lg bg-sky-700 py-2.5 text-sm font-medium text-white hover:bg-sky-800 dark:bg-blue-300 dark:text-gray-900 dark:hover:bg-blue-400 flex items-center justify-center"
           >
             <span className="inline-flex items-center gap-2">
               <LogoutIcon fontSize="small" />
@@ -216,7 +230,7 @@ export default function SidebarContent({
           <GoogleSignInButton />
         )}
       </div>
-    </div>
+    </Box>
   );
 }
 
@@ -236,7 +250,9 @@ function ThemeButton({
       type="button"
       onClick={onClick}
       className={`flex-1 flex items-center justify-center gap-1 py-2 text-xs font-medium transition-colors ${
-        active ? "bg-blue-100 text-blue-700" : "text-blue-600 hover:bg-blue-50"
+        active
+          ? "bg-sky-700 text-white dark:bg-blue-300 dark:text-gray-900"
+          : "text-gray-700 hover:bg-blue-50 dark:text-white"
       }`}
     >
       {icon}
@@ -260,10 +276,12 @@ function MenuLink({
     <Link
       href={href}
       onClick={onClick}
-      className="flex items-center gap-3 rounded-lg px-4 py-2 text-sm text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800"
+      className="flex items-center gap-3 rounded-lg px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
     >
-      {icon}
-      <span className="font-medium">{children}</span>
+      <Box sx={{ color: "primary.main" }}>{icon}</Box>
+      <Typography variant="body2" fontWeight={500} color="text.primary">
+        {children}
+      </Typography>
     </Link>
   );
 }

--- a/apps/next/src/components/ui/sidebar/sidebar-content.tsx
+++ b/apps/next/src/components/ui/sidebar/sidebar-content.tsx
@@ -13,9 +13,9 @@ import {
 import { Box, Tooltip, Typography } from "@mui/material";
 import Image from "next/image";
 import Link from "next/link";
-import type { ReactNode } from "react";
 import { useTheme } from "next-themes";
 import type React from "react";
+import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { GoogleSignInButton } from "@/components/auth/google-sign-in";
 import { signOut, useSession } from "@/utils/auth-client";
@@ -188,8 +188,16 @@ export default function SidebarContent({
                 }}
                 className="w-full flex items-center gap-3 rounded-lg px-4 py-2 text-sm text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:dark:hover:bg-transparent"
               >
-                <Box sx={{ color: "primary.main" }}><EditIcon fontSize="small" /></Box>
-                <Typography variant="body2" fontWeight={500} color="text.primary">Edit Preferences</Typography>
+                <Box sx={{ color: "primary.main" }}>
+                  <EditIcon fontSize="small" />
+                </Box>
+                <Typography
+                  variant="body2"
+                  fontWeight={500}
+                  color="text.primary"
+                >
+                  Edit Preferences
+                </Typography>
               </button>
             </span>
           </Tooltip>
@@ -252,7 +260,7 @@ function ThemeButton({
       className={`flex-1 flex items-center justify-center gap-1 py-2 text-xs font-medium transition-colors ${
         active
           ? "bg-sky-700 text-white dark:bg-blue-300 dark:text-gray-900"
-          : "text-gray-700 hover:bg-blue-50 dark:text-white"
+          : "text-gray-700 hover:bg-sky-100 dark:text-white dark:hover:bg-zinc-700"
       }`}
     >
       {icon}

--- a/apps/next/src/components/ui/toolbar.tsx
+++ b/apps/next/src/components/ui/toolbar.tsx
@@ -102,7 +102,7 @@ const MOBILE_TOOLBAR_ELEMENTS: ToolbarElement[] = [
   },
   {
     title: "Tracker",
-    href: "/tracker",
+    href: "/nutrition",
     icon: <ListAltRoundedIcon />,
   },
 ];

--- a/apps/next/src/components/ui/toolbar.tsx
+++ b/apps/next/src/components/ui/toolbar.tsx
@@ -476,7 +476,7 @@ function MobileToolbar(): React.JSX.Element {
         className={`top-0 z-50 w-full px-4 py-2.5 flex items-center justify-between ${
           isTransparent
             ? "absolute bg-transparent"
-            : "sticky bg-white dark:bg-neutral-950"
+            : "sticky bg-white dark:bg-[#27272A]"
         }`}
       >
         <span
@@ -532,7 +532,7 @@ function MobileToolbar(): React.JSX.Element {
             rounded-[28px]
             px-4 py-3
             shadow-lg
-            bg-gradient-to-b from-sky-700 to-sky-900
+            bg-gradient-to-b from-sky-700 to-sky-900 dark:from-[#8EC5FF] dark:to-[#4281CA]
           "
         >
           <div className="flex items-center justify-between">
@@ -561,13 +561,14 @@ function MobileToolbar(): React.JSX.Element {
                       color: "white",
                       opacity: active ? 1 : 0.9,
                     }}
+                    className={active ? "dark:!text-[#162456]" : ""}
                   >
                     {element.icon}
                   </div>
                   <span
                     className={`
                       text-[12px] leading-none text-white
-                      ${active ? "font-semibold" : "font-medium"}
+                      ${active ? "font-semibold dark:!text-[#162456]" : "font-medium"}
                     `}
                   >
                     {element.title}

--- a/apps/next/src/components/ui/toolbar.tsx
+++ b/apps/next/src/components/ui/toolbar.tsx
@@ -218,12 +218,16 @@ export function DesktopToolbar(): React.JSX.Element {
   return (
     <>
       <AppBar
-        position="absolute"
+        position={isTransparent ? "absolute" : "sticky"}
         className={`shadow-none ${
           isTransparent
             ? "bg-transparent bg-gradient-to-b from-black/50 to-black/0"
-            : "!bg-white dark:!bg-zinc-900 !border-b !border-zinc-200 dark:!border-zinc-700"
+            : "bg-white dark:bg-[#323235]"
         }`}
+        sx={{
+          backgroundImage: "none",
+          ...(!isTransparent && { borderBottom: 1, borderColor: "divider" }),
+        }}
       >
         <MuiToolbar className="justify-between px-4 py-1 group">
           <div className="flex-none flex items-center">

--- a/apps/next/src/components/ui/toolbar.tsx
+++ b/apps/next/src/components/ui/toolbar.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useTheme } from "next-themes";
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import FavoriteBorder from "@mui/icons-material/FavoriteBorder";
@@ -24,6 +23,7 @@ import {
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useTheme } from "next-themes";
 import type { MouseEvent } from "react";
 import { useEffect, useState } from "react";
 import { GoogleSignInButton } from "@/components/auth/google-sign-in";
@@ -135,9 +135,7 @@ function ToolbarDropdown({
         onClick={handleClick}
         endIcon={<ArrowDropDownIcon fontSize="small" />}
         className={`capitalize text-[16px] !font-medium bg-transparent ${
-          isTransparent
-            ? "text-white"
-            : "!text-black dark:!text-white"
+          isTransparent ? "text-white" : "!text-black dark:!text-white"
         }`}
       >
         {element.title}
@@ -166,11 +164,13 @@ function ToolbarDropdown({
             component={Link}
             href={child.href}
             onClick={handleClose}
-           sx={{ 
+            sx={{
               color: pathname === child.href ? "primary.main" : "text.primary",
               "&.Mui-selected": { backgroundColor: "transparent" },
-              borderLeft: pathname === child.href ? "3px solid" : "3px solid transparent",
-              borderColor: pathname === child.href ? "primary.main" : "transparent",
+              borderLeft:
+                pathname === child.href ? "3px solid" : "3px solid transparent",
+              borderColor:
+                pathname === child.href ? "primary.main" : "transparent",
             }}
           >
             {child.title}
@@ -242,7 +242,12 @@ export function DesktopToolbar(): React.JSX.Element {
               <Typography
                 className="font-poppins text-[28px] leading-[24px]"
                 fontWeight={700}
-                sx={{ color: isTransparent && resolvedTheme === "light" ? "white" : "primary.main" }}
+                sx={{
+                  color:
+                    isTransparent && resolvedTheme === "light"
+                      ? "white"
+                      : "primary.main",
+                }}
               >
                 PeterPlate
               </Typography>
@@ -269,7 +274,9 @@ export function DesktopToolbar(): React.JSX.Element {
                   className={`normal-case text-[16px] !font-medium ${
                     isTransparent
                       ? "text-white"
-                      : "!text-black dark:!text-white"
+                      : pathname === element.href
+                        ? "!text-sky-700 dark:!text-blue-300"
+                        : "!text-black dark:!text-white"
                   }`}
                 >
                   {element.title}
@@ -288,7 +295,9 @@ export function DesktopToolbar(): React.JSX.Element {
                     aria-label="Open sidebar"
                     disabled
                   >
-                    <MenuIcon sx={{ color: isTransparent ? "white" : "text.primary" }} />
+                    <MenuIcon
+                      sx={{ color: isTransparent ? "white" : "text.primary" }}
+                    />
                   </IconButton>
                 </>
               ) : user ? (
@@ -313,7 +322,9 @@ export function DesktopToolbar(): React.JSX.Element {
                     className="hover:!bg-gray-100 dark:hover:!bg-gray-700"
                     aria-label="Open sidebar"
                   >
-                    <MenuIcon sx={{ color: isTransparent ? "white" : "text.primary" }} />
+                    <MenuIcon
+                      sx={{ color: isTransparent ? "white" : "text.primary" }}
+                    />
                   </IconButton>
                 </div>
               )}

--- a/apps/next/src/components/ui/toolbar.tsx
+++ b/apps/next/src/components/ui/toolbar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTheme } from "next-themes";
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import FavoriteBorder from "@mui/icons-material/FavoriteBorder";
@@ -18,6 +19,7 @@ import {
   MenuItem,
   Toolbar as MuiToolbar,
   Snackbar,
+  Typography,
 } from "@mui/material";
 import Image from "next/image";
 import Link from "next/link";
@@ -105,14 +107,16 @@ const MOBILE_TOOLBAR_ELEMENTS: ToolbarElement[] = [
   },
 ];
 
-const TRANSPARENT_PAGES = ["/about", "/brandywine", "/anteatery", "/events"];
+const TRANSPARENT_PAGES = ["/about", "/brandywine", "/anteatery"];
 
 function ToolbarDropdown({
   element,
   isTransparent,
+  pathname,
 }: {
   element: ToolbarElement;
   isTransparent: boolean;
+  pathname: string;
 }) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
@@ -132,7 +136,7 @@ function ToolbarDropdown({
         endIcon={<ArrowDropDownIcon fontSize="small" />}
         className={`capitalize text-[16px] !font-medium bg-transparent ${
           isTransparent
-            ? "text-white/60 group-hover:text-white"
+            ? "text-white"
             : "!text-black dark:!text-white"
         }`}
       >
@@ -144,6 +148,17 @@ function ToolbarDropdown({
         onClose={handleClose}
         className="capitalize text-[16px] font-medium
         group-hover:text-white text-white/60 bg-transparent"
+        slotProps={{
+          paper: {
+            sx: {
+              backgroundImage: "none",
+              bgcolor: "#ffffff",
+              ".dark &": {
+                bgcolor: "#323235",
+              },
+            },
+          },
+        }}
       >
         {element.children?.map((child) => (
           <MenuItem
@@ -151,6 +166,12 @@ function ToolbarDropdown({
             component={Link}
             href={child.href}
             onClick={handleClose}
+           sx={{ 
+              color: pathname === child.href ? "primary.main" : "text.primary",
+              "&.Mui-selected": { backgroundColor: "transparent" },
+              borderLeft: pathname === child.href ? "3px solid" : "3px solid transparent",
+              borderColor: pathname === child.href ? "primary.main" : "transparent",
+            }}
           >
             {child.title}
           </MenuItem>
@@ -161,6 +182,7 @@ function ToolbarDropdown({
 }
 
 export function DesktopToolbar(): React.JSX.Element {
+  const { resolvedTheme } = useTheme();
   const pathname = usePathname();
   const isTransparent = TRANSPARENT_PAGES.includes(pathname);
   const isDesktop = useMediaQuery("(min-width: 768px)");
@@ -213,13 +235,13 @@ export function DesktopToolbar(): React.JSX.Element {
                 width={40}
                 height={40}
               />
-              <span
-                className={`font-poppins font-bold text-[28px] leading-[24px] ${
-                  isTransparent ? "text-white" : "text-sky-700 dark:text-white"
-                }`}
+              <Typography
+                className="font-poppins text-[28px] leading-[24px]"
+                fontWeight={700}
+                sx={{ color: isTransparent && resolvedTheme === "light" ? "white" : "primary.main" }}
               >
                 PeterPlate
-              </span>
+              </Typography>
             </Link>
           </div>
 
@@ -231,6 +253,7 @@ export function DesktopToolbar(): React.JSX.Element {
                     key={element.title}
                     element={element}
                     isTransparent={isTransparent}
+                    pathname={pathname}
                   />
                 );
               }
@@ -241,7 +264,7 @@ export function DesktopToolbar(): React.JSX.Element {
                   href={element.href || "#"}
                   className={`normal-case text-[16px] !font-medium ${
                     isTransparent
-                      ? "text-white/60 group-hover:text-white"
+                      ? "text-white"
                       : "!text-black dark:!text-white"
                   }`}
                 >
@@ -261,9 +284,7 @@ export function DesktopToolbar(): React.JSX.Element {
                     aria-label="Open sidebar"
                     disabled
                   >
-                    <MenuIcon
-                      style={{ color: isTransparent ? "white" : "black" }}
-                    />
+                    <MenuIcon sx={{ color: isTransparent ? "white" : "text.primary" }} />
                   </IconButton>
                 </>
               ) : user ? (
@@ -283,6 +304,13 @@ export function DesktopToolbar(): React.JSX.Element {
               ) : (
                 <div className="flex items-center gap-2">
                   <GoogleSignInButton />
+                  <IconButton
+                    onClick={handleProfileOpen}
+                    className="hover:!bg-gray-100 dark:hover:!bg-gray-700"
+                    aria-label="Open sidebar"
+                  >
+                    <MenuIcon sx={{ color: isTransparent ? "white" : "text.primary" }} />
+                  </IconButton>
                 </div>
               )}
             </div>

--- a/apps/next/src/components/ui/tracker-history-dialog.tsx
+++ b/apps/next/src/components/ui/tracker-history-dialog.tsx
@@ -60,9 +60,13 @@ export default function TrackerHistoryDialog({
           width: "700px",
           maxWidth: "700px",
         },
+        ".dark & .MuiDialog-paper": {
+          backgroundImage: "none",
+          backgroundColor: "#303035",
+        },
       }}
     >
-      <DialogTitle className="!font-semibold !text-sky-700">
+      <DialogTitle className="!font-semibold !text-sky-700 dark:!text-blue-300">
         What you ate on {dateLabel}
       </DialogTitle>
       <DialogContent>
@@ -87,7 +91,7 @@ export default function TrackerHistoryDialog({
         <Button
           onClick={onClose}
           variant="contained"
-          className="!bg-sky-700 !text-white !text-sm !font-semibold hover:!bg-sky-800 !rounded-lg !px-3 !py-1 !normal-case"
+          className="!bg-sky-700 !text-white !text-sm !font-semibold hover:!bg-sky-800 !rounded-lg !px-3 !py-1 !normal-case dark:!bg-blue-300 dark:!text-gray-900 dark:hover:!bg-blue-400"
         >
           Close
         </Button>

--- a/apps/next/src/components/ui/tracker-history-drawer.tsx
+++ b/apps/next/src/components/ui/tracker-history-drawer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import CloseIcon from "@mui/icons-material/Close";
-import { Drawer, IconButton } from "@mui/material";
+import { Drawer, IconButton, Typography } from "@mui/material";
 import MobileCalorieCard from "@/components/ui/mobile-calorie-card";
 import MobileNutritionBars from "@/components/ui/mobile-nutrition-bars";
 import type { LoggedMealJoinedWithNutrition } from "@/components/ui/nutrition-breakdown";
@@ -56,13 +56,17 @@ export default function TrackerHistoryDrawer({
           borderTopRightRadius: "16px",
           maxHeight: "85vh",
         },
+        ".dark & .MuiDrawer-paper": {
+          backgroundImage: "none",
+          backgroundColor: "#303035",
+        },
       }}
     >
       <div className="p-4 flex flex-col gap-4 overflow-y-auto">
         <div className="flex items-center justify-between">
-          <span className="font-semibold text-sky-700 text-lg">
+          <Typography fontWeight={600} color="primary" fontSize="1.125rem">
             What you ate on {dateLabel}
-          </span>
+          </Typography>
           <IconButton onClick={onClose} size="small">
             <CloseIcon />
           </IconButton>

--- a/apps/next/src/components/ui/tracker-history-meal-table.tsx
+++ b/apps/next/src/components/ui/tracker-history-meal-table.tsx
@@ -14,7 +14,7 @@ export default function TrackerHistoryMealTable({ mealsEaten }: Props) {
     <div className="w-full mt-4">
       <table className="w-full text-sm">
         <thead>
-          <tr className="text-zinc-800 text-left text-lg">
+          <tr className="text-zinc-800 dark:text-white text-left text-lg">
             <th className="pb-3 font-medium">Food</th>
             <th className="pb-3 font-medium">Calories</th>
             <th className="pb-3 font-medium">Protein</th>
@@ -24,11 +24,14 @@ export default function TrackerHistoryMealTable({ mealsEaten }: Props) {
         </thead>
         <tbody>
           {mealsEaten.map((meal) => (
-            <tr key={meal.id} className="border-t border-zinc-100">
+            <tr
+              key={meal.id}
+              className="border-t border-zinc-100 dark:border-zinc-700"
+            >
               <td className="py-3">
                 <div className="flex items-center gap-2 flex-wrap">
                   <span>{meal.dishName}</span>
-                  <span className="bg-sky-700 text-white text-xs rounded-full w-5 h-5 flex items-center justify-center font-medium flex-shrink-0">
+                  <span className="bg-sky-700 dark:bg-blue-300 text-white dark:text-gray-900 text-xs rounded-full w-5 h-5 flex items-center justify-center font-medium flex-shrink-0">
                     {meal.servings}
                   </span>
                 </div>

--- a/apps/next/src/components/ui/tracker-history.tsx
+++ b/apps/next/src/components/ui/tracker-history.tsx
@@ -60,7 +60,16 @@ export default function TrackerHistory({
           !loggedDates.some((d) => d.toDateString() === date.toDateString())
         }
         displayStaticWrapperAs="desktop"
-        slotProps={{ actionBar: { actions: [] } }}
+        slotProps={{
+          actionBar: { actions: [] },
+          layout: {
+            sx: {
+              backgroundColor: "var(--mui-palette-background-paper)",
+              backgroundImage: "none",
+              ".dark &": { backgroundColor: "#323235" },
+            },
+          },
+        }}
         sx={{ "& .MuiDateCalendar-root": { height: "300px" } }}
       />
     </LocalizationProvider>
@@ -71,19 +80,29 @@ export default function TrackerHistory({
       <Button
         onClick={() => setOpen(!open)}
         variant="contained"
-        className="!bg-sky-700 !text-white !text-sm !font-semibold hover:!bg-sky-800 !rounded-lg !px-3 !py-1 !normal-case"
+        className="!bg-sky-700 !text-white !text-sm !font-semibold hover:!bg-sky-800 !rounded-lg !px-3 !py-1 !normal-case dark:!bg-blue-300 dark:!text-gray-900 dark:hover:!bg-blue-400"
         endIcon={<RestoreIcon fontSize="small" />}
       >
         History
       </Button>
 
       {isMobile ? (
-        <Drawer anchor="bottom" open={open} onClose={() => setOpen(false)}>
+        <Drawer
+          anchor="bottom"
+          open={open}
+          onClose={() => setOpen(false)}
+          sx={{
+            ".dark & .MuiDrawer-paper": {
+              backgroundImage: "none",
+              backgroundColor: "#323235",
+            },
+          }}
+        >
           <div className="p-4">{calendar}</div>
         </Drawer>
       ) : (
         open && (
-          <div className="absolute top-full mt-2 right-0 z-50 bg-white rounded-xl border border-sky-700/30 p-4 shadow-md">
+          <div className="absolute top-full mt-2 right-0 z-50 bg-white dark:bg-[#323235] rounded-xl border border-sky-700 dark:border-blue-300 p-4 shadow-md">
             {calendar}
           </div>
         )


### PR DESCRIPTION
## Summary
Adds full dark mode support to PeterPlate and cleans up the codebase by replacing hardcoded HTML elements with proper MUI components. Used MUI's built-in theming where possible, and fell back to Tailwind dark: variants where MUI didn't play nice. Also fixed some pre-existing light mode color issues along the way. Theme switching is handled by next-themes.

## Changes
- Set up the MUI dark palette and updated the dark mode CSS variables to match the Figma design
- Replaced hardcoded text and layout elements with MUI Typography and Box components across the codebase, using semantic color props that automatically respond to the active theme
- Fixed light mode color inconsistencies across the toolbar, sidebar, restaurant filters, cards, and dialogs
- Updated interactive elements (dropdowns, meal selector, station tabs, view toggles, buttons, badges) to use the correct colors in both modes

Additionally closes #656 and few others

## Testing Instructions
1. nvm use 20 && docker compose up -d && pnpm run dev
2. Seed: pnpm --filter @peterplate/db db:migrate && cd apps/server && pnpm run test:weekly
3. Toggle Light/Device/Dark via the profile sidebar and check the home page, restaurant pages, events, about, and any dialogs