### PR TITLE
refactor: extract useRestaurantPage hook and fix any types in restaurant components

### DIFF
--- a/apps/next/src/components/ui/restaurant/dishes-view.tsx
+++ b/apps/next/src/components/ui/restaurant/dishes-view.tsx
@@ -1,7 +1,7 @@
 import type { AppRouter, FormattedRestaurantInfo, Station } from "@api/index";
 import { Typography } from "@mui/material";
-import type { DishWithRating } from "@peterplate/validators";
 import type { TRPCClientErrorLike } from "@trpc/client";
+import { useMemo } from "react";
 import DishesInfo from "@/components/ui/dishes-info";
 import { useRestaurantUIStore } from "@/context/useRestaurantUIStore";
 import { useUserStore } from "@/context/useUserStore";
@@ -43,14 +43,26 @@ export function DishesView({
     userId: userId ?? "",
   });
 
-  const getFilteredDishes = (dishes: DishWithRating[]) => {
-    if (!showPreferencesOnly || !allergies || !preferences) return dishes;
-    return dishes.filter(
-      (dish) =>
-        getDietaryConflicts(dish.dietRestriction, preferences, allergies)
-          .length === 0,
+  // Pre-compute filtered dishes for every station so toggling isCompactView
+  // (which switches from single-station to all-stations) doesn't recompute
+  // getDietaryConflicts for every dish on each render.
+  const filteredDishesMap = useMemo(() => {
+    return new Map(
+      stations.map((station) => [
+        station.name,
+        showPreferencesOnly && allergies && preferences
+          ? station.dishes.filter(
+              (dish) =>
+                getDietaryConflicts(
+                  dish.dietRestriction,
+                  preferences,
+                  allergies,
+                ).length === 0,
+            )
+          : station.dishes,
+      ]),
     );
-  };
+  }, [stations, showPreferencesOnly, preferences, allergies]);
 
   return (
     <div className="w-full">
@@ -73,7 +85,7 @@ export function DishesView({
                 </Typography>
               </div>
               <DishesInfo
-                dishes={getFilteredDishes(station.dishes)}
+                dishes={filteredDishesMap.get(station.name) ?? station.dishes}
                 isLoading={isLoading}
                 isError={isError || (!isLoading && !hallData)}
                 errorMessage={errorMessage}
@@ -96,7 +108,10 @@ export function DishesView({
                 </Typography>
               </div>
               <DishesInfo
-                dishes={getFilteredDishes(activeStation?.dishes ?? [])}
+                dishes={
+                  filteredDishesMap.get(activeStation.name) ??
+                  activeStation.dishes
+                }
                 isLoading={isLoading}
                 isError={isError || (!isLoading && !hallData)}
                 errorMessage={errorMessage}

--- a/apps/next/src/components/ui/restaurant/dishes-view.tsx
+++ b/apps/next/src/components/ui/restaurant/dishes-view.tsx
@@ -3,43 +3,37 @@ import { Typography } from "@mui/material";
 import type { DishWithRating } from "@peterplate/validators";
 import type { TRPCClientErrorLike } from "@trpc/client";
 import DishesInfo from "@/components/ui/dishes-info";
+import { useRestaurantUIStore } from "@/context/useRestaurantUIStore";
 import { useUserStore } from "@/context/useUserStore";
 import { getDietaryConflicts } from "@/utils/dietary";
 import { toTitleCase } from "@/utils/funcs";
 import { trpc } from "@/utils/trpc";
 
 interface DishesViewProps {
-  isCompactView: boolean;
   stations: Station[];
   activeStation: Station | undefined;
   isLoading: boolean;
   isError: boolean;
   error: TRPCClientErrorLike<AppRouter> | null;
   hallData: FormattedRestaurantInfo | undefined;
-  showPreferencesOnly: boolean;
 }
 
 export function DishesView({
-  isCompactView,
   stations,
   activeStation,
   isLoading,
   isError,
   error,
   hallData,
-  showPreferencesOnly,
 }: DishesViewProps) {
-  // Helper to extract error message logic
-  const getErrorMessage = () => {
-    return (
-      error?.message ??
-      (!isLoading && !hallData
-        ? "Data not available for this hall."
-        : undefined)
-    );
-  };
+  const isCompactView = useRestaurantUIStore((s) => s.isCompactView);
+  const showPreferencesOnly = useRestaurantUIStore(
+    (s) => s.showPreferencesOnly,
+  );
 
-  const errorMessage = getErrorMessage();
+  const errorMessage =
+    error?.message ??
+    (!isLoading && !hallData ? "Data not available for this hall." : undefined);
 
   const userId = useUserStore((s) => s.userId);
   const { data: preferences } = trpc.preference.getDietaryPreferences.useQuery({
@@ -88,7 +82,7 @@ export function DishesView({
               />
             </div>
           ))
-        : // Normal View: Render active station logic
+        : // Normal View: Render active station
           activeStation && (
             <div className="[&_#food-scroll]:h-auto [&_#food-scroll]:overflow-y-visible">
               <div className="mb-4">

--- a/apps/next/src/components/ui/restaurant/dishes-view.tsx
+++ b/apps/next/src/components/ui/restaurant/dishes-view.tsx
@@ -48,7 +48,7 @@ export function DishesView({
     return dishes.filter(
       (dish) =>
         getDietaryConflicts(dish.dietRestriction, preferences, allergies)
-          .length > 0,
+          .length === 0,
     );
   };
 

--- a/apps/next/src/components/ui/restaurant/dishes-view.tsx
+++ b/apps/next/src/components/ui/restaurant/dishes-view.tsx
@@ -11,7 +11,7 @@ import { trpc } from "@/utils/trpc";
 interface DishesViewProps {
   isCompactView: boolean;
   stations: Station[];
-  activeStation: Station;
+  activeStation: Station | undefined;
   isLoading: boolean;
   isError: boolean;
   error: TRPCClientErrorLike<AppRouter> | null;

--- a/apps/next/src/components/ui/restaurant/header/desktop-tabs.tsx
+++ b/apps/next/src/components/ui/restaurant/header/desktop-tabs.tsx
@@ -1,3 +1,4 @@
+import type { Station } from "@api/index";
 import { GridView, Menu as MenuIcon } from "@mui/icons-material";
 import { Button, Tab, Tabs } from "@mui/material";
 import { toTitleCase } from "@/utils/funcs";
@@ -6,7 +7,7 @@ interface DesktopTabsProps {
   isDesktop: boolean;
   isLoading: boolean;
   isError: boolean;
-  stations: any[];
+  stations: Station[];
   selectedStation: string;
   setSelectedStation: (station: string) => void;
   isCompactView: boolean;

--- a/apps/next/src/components/ui/restaurant/header/desktop-tabs.tsx
+++ b/apps/next/src/components/ui/restaurant/header/desktop-tabs.tsx
@@ -1,6 +1,7 @@
 import type { Station } from "@api/index";
 import { GridView, Menu as MenuIcon } from "@mui/icons-material";
 import { Button, Tab, Tabs } from "@mui/material";
+import { useRestaurantUIStore } from "@/context/useRestaurantUIStore";
 import { toTitleCase } from "@/utils/funcs";
 
 interface DesktopTabsProps {
@@ -8,10 +9,6 @@ interface DesktopTabsProps {
   isLoading: boolean;
   isError: boolean;
   stations: Station[];
-  selectedStation: string;
-  setSelectedStation: (station: string) => void;
-  isCompactView: boolean;
-  setIsCompactView: (isCompact: boolean) => void;
 }
 
 export function DesktopTabs({
@@ -19,11 +16,12 @@ export function DesktopTabs({
   isLoading,
   isError,
   stations,
-  selectedStation,
-  setSelectedStation,
-  isCompactView,
-  setIsCompactView,
 }: DesktopTabsProps) {
+  const selectedStation = useRestaurantUIStore((s) => s.selectedStation);
+  const setSelectedStation = useRestaurantUIStore((s) => s.setSelectedStation);
+  const isCompactView = useRestaurantUIStore((s) => s.isCompactView);
+  const setIsCompactView = useRestaurantUIStore((s) => s.setIsCompactView);
+
   if (!isDesktop) return null;
 
   return (
@@ -41,10 +39,8 @@ export function DesktopTabs({
                   block: "start",
                 });
               }
-              setSelectedStation(val);
-            } else {
-              setSelectedStation(val);
             }
+            setSelectedStation(val);
           }}
           className="flex w-full overflow-x-auto no-scrollbar !bg-sky-700/40 dark:!bg-[#46566a] !rounded-lg !p-2 [&_.MuiTabs-flexContainer]:justify-between [&_.MuiTabs-flexContainer]:gap-2 [&_.MuiTabs-indicator]:hidden"
           variant="scrollable"
@@ -60,7 +56,7 @@ export function DesktopTabs({
           ))}
         </Tabs>
       )}
-      {/* Card/compact view toggles */}
+      {/* Card / compact view toggles */}
       <div className="flex justify-end mt-2">
         <div className="flex gap-2">
           <Button

--- a/apps/next/src/components/ui/restaurant/header/mobile-actions.tsx
+++ b/apps/next/src/components/ui/restaurant/header/mobile-actions.tsx
@@ -1,3 +1,4 @@
+import type { Station } from "@api/index";
 import {
   ExpandMore,
   GridView,
@@ -15,19 +16,20 @@ import {
   ToggleButtonGroup,
   Typography,
 } from "@mui/material";
+import type { DishWithRating, Event } from "@peterplate/validators";
 import { toTitleCase } from "@/utils/funcs";
 
 interface MobileActionsProps {
   isDesktop: boolean;
   isLoading: boolean;
   isError: boolean;
-  dishes: any[];
-  stations: any[];
+  dishes: DishWithRating[];
+  stations: Station[];
   menuAnchor: HTMLElement | null;
   setMenuAnchor: (el: HTMLElement | null) => void;
   scheduleAnchor: HTMLElement | null;
   setScheduleAnchor: (el: HTMLElement | null) => void;
-  hallEvents: any[];
+  hallEvents: Event[];
   isCompactView: boolean;
   setIsCompactView: (isCompact: boolean) => void;
   setSelectedStation: (station: string) => void;
@@ -209,7 +211,7 @@ export function MobileActions({
                         </AccordionSummary>
                         <AccordionDetails className="pt-0 pb-2">
                           <Typography variant="body2" color="text.secondary">
-                            {event.shortDescription ?? dateRange}
+                            {event.description ?? dateRange}
                           </Typography>
                         </AccordionDetails>
                       </Accordion>

--- a/apps/next/src/components/ui/restaurant/header/mobile-actions.tsx
+++ b/apps/next/src/components/ui/restaurant/header/mobile-actions.tsx
@@ -17,6 +17,7 @@ import {
   Typography,
 } from "@mui/material";
 import type { DishWithRating, Event } from "@peterplate/validators";
+import { useRestaurantUIStore } from "@/context/useRestaurantUIStore";
 import { toTitleCase } from "@/utils/funcs";
 
 interface MobileActionsProps {
@@ -25,14 +26,7 @@ interface MobileActionsProps {
   isError: boolean;
   dishes: DishWithRating[];
   stations: Station[];
-  menuAnchor: HTMLElement | null;
-  setMenuAnchor: (el: HTMLElement | null) => void;
-  scheduleAnchor: HTMLElement | null;
-  setScheduleAnchor: (el: HTMLElement | null) => void;
   hallEvents: Event[];
-  isCompactView: boolean;
-  setIsCompactView: (isCompact: boolean) => void;
-  setSelectedStation: (station: string) => void;
 }
 
 export function MobileActions({
@@ -41,15 +35,16 @@ export function MobileActions({
   isError,
   dishes,
   stations,
-  menuAnchor,
-  setMenuAnchor,
-  scheduleAnchor,
-  setScheduleAnchor,
   hallEvents,
-  isCompactView,
-  setIsCompactView,
-  setSelectedStation,
 }: MobileActionsProps) {
+  const menuAnchor = useRestaurantUIStore((s) => s.menuAnchor);
+  const setMenuAnchor = useRestaurantUIStore((s) => s.setMenuAnchor);
+  const scheduleAnchor = useRestaurantUIStore((s) => s.scheduleAnchor);
+  const setScheduleAnchor = useRestaurantUIStore((s) => s.setScheduleAnchor);
+  const isCompactView = useRestaurantUIStore((s) => s.isCompactView);
+  const setIsCompactView = useRestaurantUIStore((s) => s.setIsCompactView);
+  const setSelectedStation = useRestaurantUIStore((s) => s.setSelectedStation);
+
   if (isDesktop) return null;
 
   return (
@@ -103,10 +98,8 @@ export function MobileActions({
                             block: "start",
                           });
                         }
-                        setSelectedStation(val);
-                      } else {
-                        setSelectedStation(val);
                       }
+                      setSelectedStation(val);
                       setMenuAnchor(null);
                     }}
                   >

--- a/apps/next/src/components/ui/restaurant/header/restaurant-filters.tsx
+++ b/apps/next/src/components/ui/restaurant/header/restaurant-filters.tsx
@@ -14,6 +14,7 @@ import { DatePicker } from "@mui/x-date-pickers/DatePicker";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { useTheme } from "next-themes";
 import type { CalendarRange } from "@/components/ui/toolbar";
+import { useRestaurantUIStore } from "@/context/useRestaurantUIStore";
 import { useUserStore } from "@/context/useUserStore";
 import { formatOpenCloseTime, toTitleCase } from "@/utils/funcs";
 import { cn } from "@/utils/tw";
@@ -22,33 +23,36 @@ interface RestaurantFiltersProps {
   isDesktop: boolean;
   periods: string[];
   availablePeriodTimes: Record<string, [Date, Date] | null> | undefined;
-  selectedPeriod: string;
-  setSelectedPeriod: (period: string) => void;
+  // Date selection is owned by date-context, not the UI store
   selectedDate: Date | undefined;
   handleDateSelect: (date: Date | undefined) => void;
   calendarRange: CalendarRange | null;
-  isDatePickerOpen: boolean;
-  setIsDatePickerOpen: (isOpen: boolean) => void;
-  showPreferencesOnly: boolean;
-  setShowPreferencesOnly: (isSet: boolean) => void;
 }
 
 export function RestaurantFilters({
   isDesktop,
   periods,
   availablePeriodTimes,
-  selectedPeriod,
-  setSelectedPeriod,
   selectedDate,
   handleDateSelect,
   calendarRange,
-  isDatePickerOpen,
-  setIsDatePickerOpen,
-  showPreferencesOnly,
-  setShowPreferencesOnly,
 }: RestaurantFiltersProps) {
   const { resolvedTheme } = useTheme();
   const { userId } = useUserStore();
+
+  const selectedPeriod = useRestaurantUIStore((s) => s.selectedPeriod);
+  const setSelectedPeriod = useRestaurantUIStore((s) => s.setSelectedPeriod);
+  const isDatePickerOpen = useRestaurantUIStore((s) => s.isDatePickerOpen);
+  const setIsDatePickerOpen = useRestaurantUIStore(
+    (s) => s.setIsDatePickerOpen,
+  );
+  const showPreferencesOnly = useRestaurantUIStore(
+    (s) => s.showPreferencesOnly,
+  );
+  const setShowPreferencesOnly = useRestaurantUIStore(
+    (s) => s.setShowPreferencesOnly,
+  );
+
   const ShowPrefsButton = (
     <button
       type="button"

--- a/apps/next/src/components/ui/restaurant/restaurant-controls.tsx
+++ b/apps/next/src/components/ui/restaurant/restaurant-controls.tsx
@@ -1,4 +1,5 @@
-import type { DishWithRating } from "@peterplate/validators";
+import type { Station } from "@api/index";
+import type { DishWithRating, Event } from "@peterplate/validators";
 import { DiningHallStatus } from "@/components/ui/status";
 import type { CalendarRange } from "@/components/ui/toolbar";
 import type { HallEnum, HallStatusEnum } from "@/utils/types";
@@ -23,12 +24,12 @@ interface RestaurantControlsProps {
   isLoading: boolean;
   isError: boolean;
   dishes: DishWithRating[];
-  stations: any[];
+  stations: Station[];
   menuAnchor: HTMLElement | null;
   setMenuAnchor: (el: HTMLElement | null) => void;
   scheduleAnchor: HTMLElement | null;
   setScheduleAnchor: (el: HTMLElement | null) => void;
-  hallEvents: any[];
+  hallEvents: Event[];
   isCompactView: boolean;
   setIsCompactView: (isCompact: boolean) => void;
   selectedStation: string;
@@ -69,21 +70,20 @@ export function RestaurantControls({
   return (
     <>
       <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-2 mb-2 flex-wrap md:flex-nowrap">
-        {/* Desktop title & status (Header) */}
+        {/* Desktop title & status */}
         <RestaurantHeader isDesktop={isDesktop} hall={hall} />
 
         <div className="flex flex-col gap-3 w-full md:w-auto md:flex-row md:items-center md:justify-end">
-          {/* Desktop Status - now next to selectors */}
+          {/* Status badge — desktop only, shown next to filters */}
           {isDesktop && (
             <div>
               <DiningHallStatus status={derivedHallStatus} />
             </div>
           )}
 
-          {/* Meal & date selectors (Filters) */}
+          {/* Meal & date selectors */}
           <RestaurantFilters
             isDesktop={isDesktop}
-            // ... filters props
             periods={periods}
             availablePeriodTimes={availablePeriodTimes}
             selectedPeriod={selectedPeriod}
@@ -97,9 +97,8 @@ export function RestaurantControls({
             setShowPreferencesOnly={setShowPreferencesOnly}
           />
 
-          {/* Mobile Actions */}
+          {/* Menu / schedule popovers & view-toggle (mobile only) */}
           <MobileActions
-            // ... mobile actions props
             isDesktop={isDesktop}
             isLoading={isLoading}
             isError={isError}
@@ -117,7 +116,7 @@ export function RestaurantControls({
         </div>
       </div>
 
-      {/* Desktop Tabs */}
+      {/* Station tabs & card/compact view toggles (desktop only) */}
       <DesktopTabs
         isDesktop={isDesktop}
         isLoading={isLoading}

--- a/apps/next/src/components/ui/restaurant/restaurant-controls.tsx
+++ b/apps/next/src/components/ui/restaurant/restaurant-controls.tsx
@@ -12,7 +12,6 @@ interface RestaurantControlsProps {
   hall: HallEnum;
   isDesktop: boolean;
   derivedHallStatus: HallStatusEnum;
-  // Period list & times — derived from hall data, not user state
   periods: string[];
   availablePeriodTimes: Record<string, [Date, Date] | null> | undefined;
   // Date selection — owned by date-context, not the UI store
@@ -56,11 +55,7 @@ export function RestaurantControls({
             </div>
           )}
 
-          {/*
-            Meal & date selectors.
-            selectedPeriod / setSelectedPeriod / showPreferencesOnly /
-            isDatePickerOpen are read from useRestaurantUIStore inside.
-          */}
+          {/* Meal & date selectors */}
           <RestaurantFilters
             isDesktop={isDesktop}
             periods={periods}
@@ -70,11 +65,7 @@ export function RestaurantControls({
             calendarRange={calendarRange}
           />
 
-          {/*
-            Menu / schedule popovers & view-toggle (mobile only).
-            isCompactView / menuAnchor / scheduleAnchor are read from
-            useRestaurantUIStore inside.
-          */}
+          {/* Menu / schedule popovers & view-toggle (mobile only) */}
           <MobileActions
             isDesktop={isDesktop}
             isLoading={isLoading}
@@ -86,10 +77,7 @@ export function RestaurantControls({
         </div>
       </div>
 
-      {/*
-        Station tabs & card/compact view toggles (desktop only).
-        selectedStation / isCompactView are read from useRestaurantUIStore inside.
-      */}
+      {/* Station tabs & card/compact view toggles (desktop only) */}
       <DesktopTabs
         isDesktop={isDesktop}
         isLoading={isLoading}

--- a/apps/next/src/components/ui/restaurant/restaurant-controls.tsx
+++ b/apps/next/src/components/ui/restaurant/restaurant-controls.tsx
@@ -12,30 +12,19 @@ interface RestaurantControlsProps {
   hall: HallEnum;
   isDesktop: boolean;
   derivedHallStatus: HallStatusEnum;
+  // Period list & times — derived from hall data, not user state
   periods: string[];
   availablePeriodTimes: Record<string, [Date, Date] | null> | undefined;
-  selectedPeriod: string;
-  setSelectedPeriod: (period: string) => void;
+  // Date selection — owned by date-context, not the UI store
   selectedDate: Date | undefined;
   handleDateSelect: (date: Date | undefined) => void;
   calendarRange: CalendarRange | null;
-  isDatePickerOpen: boolean;
-  setIsDatePickerOpen: (isOpen: boolean) => void;
+  // Loading / data for conditional rendering
   isLoading: boolean;
   isError: boolean;
   dishes: DishWithRating[];
   stations: Station[];
-  menuAnchor: HTMLElement | null;
-  setMenuAnchor: (el: HTMLElement | null) => void;
-  scheduleAnchor: HTMLElement | null;
-  setScheduleAnchor: (el: HTMLElement | null) => void;
   hallEvents: Event[];
-  isCompactView: boolean;
-  setIsCompactView: (isCompact: boolean) => void;
-  selectedStation: string;
-  setSelectedStation: (station: string) => void;
-  showPreferencesOnly: boolean;
-  setShowPreferencesOnly: (isSet: boolean) => void;
 }
 
 export function RestaurantControls({
@@ -44,33 +33,19 @@ export function RestaurantControls({
   derivedHallStatus,
   periods,
   availablePeriodTimes,
-  selectedPeriod,
-  setSelectedPeriod,
   selectedDate,
   handleDateSelect,
   calendarRange,
-  isDatePickerOpen,
-  setIsDatePickerOpen,
   isLoading,
   isError,
   dishes,
   stations,
-  menuAnchor,
-  setMenuAnchor,
-  scheduleAnchor,
-  setScheduleAnchor,
   hallEvents,
-  isCompactView,
-  setIsCompactView,
-  selectedStation,
-  setSelectedStation,
-  showPreferencesOnly,
-  setShowPreferencesOnly,
 }: RestaurantControlsProps) {
   return (
     <>
       <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-2 mb-2 flex-wrap md:flex-nowrap">
-        {/* Desktop title & status */}
+        {/* Desktop title */}
         <RestaurantHeader isDesktop={isDesktop} hall={hall} />
 
         <div className="flex flex-col gap-3 w-full md:w-auto md:flex-row md:items-center md:justify-end">
@@ -81,51 +56,45 @@ export function RestaurantControls({
             </div>
           )}
 
-          {/* Meal & date selectors */}
+          {/*
+            Meal & date selectors.
+            selectedPeriod / setSelectedPeriod / showPreferencesOnly /
+            isDatePickerOpen are read from useRestaurantUIStore inside.
+          */}
           <RestaurantFilters
             isDesktop={isDesktop}
             periods={periods}
             availablePeriodTimes={availablePeriodTimes}
-            selectedPeriod={selectedPeriod}
-            setSelectedPeriod={setSelectedPeriod}
             selectedDate={selectedDate}
             handleDateSelect={handleDateSelect}
             calendarRange={calendarRange}
-            isDatePickerOpen={isDatePickerOpen}
-            setIsDatePickerOpen={setIsDatePickerOpen}
-            showPreferencesOnly={showPreferencesOnly}
-            setShowPreferencesOnly={setShowPreferencesOnly}
           />
 
-          {/* Menu / schedule popovers & view-toggle (mobile only) */}
+          {/*
+            Menu / schedule popovers & view-toggle (mobile only).
+            isCompactView / menuAnchor / scheduleAnchor are read from
+            useRestaurantUIStore inside.
+          */}
           <MobileActions
             isDesktop={isDesktop}
             isLoading={isLoading}
             isError={isError}
             dishes={dishes}
             stations={stations}
-            menuAnchor={menuAnchor}
-            setMenuAnchor={setMenuAnchor}
-            scheduleAnchor={scheduleAnchor}
-            setScheduleAnchor={setScheduleAnchor}
             hallEvents={hallEvents}
-            isCompactView={isCompactView}
-            setIsCompactView={setIsCompactView}
-            setSelectedStation={setSelectedStation}
           />
         </div>
       </div>
 
-      {/* Station tabs & card/compact view toggles (desktop only) */}
+      {/*
+        Station tabs & card/compact view toggles (desktop only).
+        selectedStation / isCompactView are read from useRestaurantUIStore inside.
+      */}
       <DesktopTabs
         isDesktop={isDesktop}
         isLoading={isLoading}
         isError={isError}
         stations={stations}
-        selectedStation={selectedStation}
-        setSelectedStation={setSelectedStation}
-        isCompactView={isCompactView}
-        setIsCompactView={setIsCompactView}
       />
     </>
   );

--- a/apps/next/src/components/ui/restaurant/restaurant-page.tsx
+++ b/apps/next/src/components/ui/restaurant/restaurant-page.tsx
@@ -1,19 +1,12 @@
 "use client";
 
+import type { AppRouter } from "@api/index";
 import { LocationOn } from "@mui/icons-material";
 import { Box, Container, Link, Typography } from "@mui/material";
-import type { FormattedRestaurantInfo } from "@peterplate/api";
+import type { TRPCClientErrorLike } from "@trpc/client";
 import Image from "next/image";
-import { useEffect, useMemo, useState } from "react";
-import type { CalendarRange } from "@/components/ui/toolbar";
-import { useDate } from "@/context/date-context";
-import {
-  useHallDerived,
-  useRestaurantStore,
-} from "@/context/useRestaurantStore";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
-import { isSameDay } from "@/utils/funcs";
-import { trpc } from "@/utils/trpc";
+import { useRestaurantPage } from "@/hooks/useRestaurantPage";
 import {
   ANTEATERY_MAP_LINK_URL,
   BRANDYWINE_MAP_LINK_URL,
@@ -33,156 +26,44 @@ export function RestaurantPage({
 }: RestaurantPageProps): React.JSX.Element {
   const isDesktop = useMediaQuery("(min-width: 768px)");
 
-  const { selectedDate, setSelectedDate } = useDate();
-  const today = useRestaurantStore((s) => s.today);
-  const setHallInputs = useRestaurantStore((s) => s.setInputs);
-
-  const [showPreferencesOnly, setShowPreferencesOnly] = useState(false);
-
-  const [calendarRange, setCalendarRange] = useState<CalendarRange | null>(
-    null,
-  );
-
-  const { data: dateRes } = trpc.pickableDates.useQuery();
-
-  useEffect(() => {
-    if (dateRes) {
-      setCalendarRange(dateRes);
-    }
-  }, [dateRes]);
-
-  const handleDateSelect = (newDateFromPicker: Date | undefined) => {
-    if (newDateFromPicker) {
-      const todayLocal = new Date();
-      if (
-        newDateFromPicker.getFullYear() === todayLocal.getFullYear() &&
-        newDateFromPicker.getMonth() === todayLocal.getMonth() &&
-        newDateFromPicker.getDate() === todayLocal.getDate()
-      ) {
-        setSelectedDate(new Date());
-      } else {
-        setSelectedDate(newDateFromPicker);
-      }
-    } else {
-      setSelectedDate(undefined);
-    }
-  };
-
-  const restaurantId = hall === HallEnum.ANTEATERY ? "anteatery" : "brandywine";
-  const { data, isLoading, isError, error } = trpc.restaurant.useQuery(
-    { date: selectedDate ?? today, restaurant: restaurantId },
-    { staleTime: 2 * 60 * 60 * 1000 },
-  );
-
-  const { data: upcomingEvents = [] } = trpc.event.upcoming.useQuery();
-  const hallEvents = useMemo(
-    () =>
-      [...upcomingEvents]
-        .filter((e) => e.restaurantId === restaurantId)
-        .sort(
-          (a, b) =>
-            (a.start ? new Date(a.start).getTime() : 0) -
-            (b.start ? new Date(b.start).getTime() : 0),
-        ),
-    [upcomingEvents, restaurantId],
-  );
-
-  const hallData: FormattedRestaurantInfo | undefined = useMemo(() => {
-    if (isLoading || isError || !data) return undefined;
-    return data;
-  }, [data, isError, isLoading]);
-
-  useEffect(() => {
-    if (hallData && selectedDate) {
-      setHallInputs({ hallData, selectedDate, restaurant: restaurantId });
-    }
-  }, [hallData, selectedDate, setHallInputs, restaurantId]);
-
-  const { availablePeriodTimes, derivedHallStatus, openTime, closeTime } =
-    useHallDerived();
-
-  const periods = useMemo(() => {
-    const times = availablePeriodTimes ?? {};
-    return Object.keys(times).sort((a, b) => {
-      const startA = times[a]?.[0];
-      const startB = times[b]?.[0];
-      if (startA == null && startB == null) return 0;
-      if (startA == null) return 1;
-      if (startB == null) return -1;
-      return startA <= startB ? -1 : 1;
-    });
-  }, [availablePeriodTimes]);
-
-  const [selectedPeriod, setSelectedPeriod] = useState("");
-  const [selectedStation, setSelectedStation] = useState("");
-  const [isCompactView, setIsCompactView] = useState(false);
-  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
-  const [scheduleAnchor, setScheduleAnchor] = useState<HTMLElement | null>(
-    null,
-  );
-  const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
-
-  useEffect(() => {
-    if (!selectedDate || periods.length === 0) {
-      if (selectedPeriod !== "") {
-        setSelectedPeriod("");
-      }
-      return;
-    }
-
-    const isValid = periods.includes(selectedPeriod);
-
-    if (!isSameDay(selectedDate, today) && !selectedPeriod) {
-      setSelectedPeriod(periods[0]);
-      return;
-    }
-
-    if (!isValid) {
-      const current = getCurrentPeriod(selectedDate, availablePeriodTimes);
-      if (current !== selectedPeriod) {
-        setSelectedPeriod(current);
-      }
-    }
-  }, [availablePeriodTimes, periods, selectedDate, selectedPeriod, today]);
-
-  const currentMenu = useMemo(
-    () =>
-      hallData?.periods.find(
-        (period) => period.name.toLowerCase() === selectedPeriod.toLowerCase(),
-      ) ?? null,
-    [hallData, selectedPeriod],
-  );
-
-  const stations = currentMenu?.stations ?? [];
-
-  useEffect(() => {
-    if (stations.length === 0) {
-      if (selectedStation !== "") {
-        setSelectedStation("");
-      }
-      return;
-    }
-
-    const firstStation = stations[0].name.toLowerCase();
-    const isValid = stations.some(
-      (s) => s.name.toLowerCase() === selectedStation,
-    );
-
-    if (!isValid) setSelectedStation(firstStation);
-  }, [selectedStation, stations]);
-
-  const activeStation =
-    stations.find((s) => s.name.toLowerCase() === selectedStation) ??
-    stations[0];
-
-  const dishes = activeStation?.dishes ?? [];
+  const {
+    hallData,
+    isLoading,
+    isError,
+    error,
+    hallEvents,
+    periods,
+    selectedPeriod,
+    setSelectedPeriod,
+    selectedStation,
+    setSelectedStation,
+    activeStation,
+    stations,
+    dishes,
+    isCompactView,
+    setIsCompactView,
+    showPreferencesOnly,
+    setShowPreferencesOnly,
+    selectedDate,
+    handleDateSelect,
+    calendarRange,
+    isDatePickerOpen,
+    setIsDatePickerOpen,
+    displayDate,
+    menuAnchor,
+    setMenuAnchor,
+    scheduleAnchor,
+    setScheduleAnchor,
+    derivedHallStatus,
+    openTime,
+    closeTime,
+    availablePeriodTimes,
+  } = useRestaurantPage(hall);
 
   const hero =
     hall === HallEnum.ANTEATERY
       ? { src: "/anteatery.webp", alt: "Anteatery dining hall" }
       : { src: "/brandywine.webp", alt: "Brandywine dining hall" };
-
-  const displayDate = selectedDate ?? today;
 
   return (
     <Box sx={{ bgcolor: "background.default", minHeight: "100vh" }}>
@@ -196,6 +77,7 @@ export function RestaurantPage({
           className="object-cover object-bottom"
         />
         <div className="absolute inset-0 bg-gradient-to-tr from-black/80 via-black/20 to-transparent" />
+
         {/* Mobile Header Overlay */}
         {!isDesktop && (
           <div className="absolute bottom-0 left-0 p-4 w-full text-white">
@@ -287,7 +169,7 @@ export function RestaurantPage({
                 activeStation={activeStation}
                 isLoading={isLoading}
                 isError={isError}
-                error={error}
+                error={error as TRPCClientErrorLike<AppRouter> | null}
                 hallData={hallData}
                 showPreferencesOnly={showPreferencesOnly}
               />
@@ -308,18 +190,4 @@ export function RestaurantPage({
       </Container>
     </Box>
   );
-}
-
-function getCurrentPeriod(
-  selectedDate: Date,
-  periods: { [periodName: string]: [Date, Date] },
-): string {
-  for (const key in periods) {
-    const periodBegin: Date = periods[key][0];
-    const periodEnd: Date = periods[key][1];
-
-    if (selectedDate >= periodBegin && selectedDate <= periodEnd) return key;
-  }
-
-  return Object.keys(periods)[0];
 }

--- a/apps/next/src/components/ui/restaurant/restaurant-page.tsx
+++ b/apps/next/src/components/ui/restaurant/restaurant-page.tsx
@@ -118,11 +118,6 @@ export function RestaurantPage({
         <div className="flex flex-col md:flex-row items-start gap-3">
           {/* Left column: menu controls & dishes */}
           <div className="w-full flex-1 md:min-h-[740px] min-w-0">
-            {/*
-              RestaurantControls reads UI state (period, station, toggles,
-              anchors) directly from useRestaurantUIStore — no prop drilling.
-              Only query-derived data that components can't self-fetch is passed.
-            */}
             <RestaurantControls
               hall={hall}
               isDesktop={isDesktop}

--- a/apps/next/src/components/ui/restaurant/restaurant-page.tsx
+++ b/apps/next/src/components/ui/restaurant/restaurant-page.tsx
@@ -33,31 +33,17 @@ export function RestaurantPage({
     error,
     hallEvents,
     periods,
-    selectedPeriod,
-    setSelectedPeriod,
-    selectedStation,
-    setSelectedStation,
     activeStation,
     stations,
     dishes,
-    isCompactView,
-    setIsCompactView,
-    showPreferencesOnly,
-    setShowPreferencesOnly,
-    selectedDate,
-    handleDateSelect,
     calendarRange,
-    isDatePickerOpen,
-    setIsDatePickerOpen,
     displayDate,
-    menuAnchor,
-    setMenuAnchor,
-    scheduleAnchor,
-    setScheduleAnchor,
-    derivedHallStatus,
     openTime,
     closeTime,
+    derivedHallStatus,
     availablePeriodTimes,
+    selectedDate,
+    handleDateSelect,
   } = useRestaurantPage(hall);
 
   const hero =
@@ -132,46 +118,35 @@ export function RestaurantPage({
         <div className="flex flex-col md:flex-row items-start gap-3">
           {/* Left column: menu controls & dishes */}
           <div className="w-full flex-1 md:min-h-[740px] min-w-0">
+            {/*
+              RestaurantControls reads UI state (period, station, toggles,
+              anchors) directly from useRestaurantUIStore — no prop drilling.
+              Only query-derived data that components can't self-fetch is passed.
+            */}
             <RestaurantControls
               hall={hall}
               isDesktop={isDesktop}
               derivedHallStatus={derivedHallStatus}
               periods={periods}
               availablePeriodTimes={availablePeriodTimes}
-              selectedPeriod={selectedPeriod}
-              setSelectedPeriod={setSelectedPeriod}
               selectedDate={selectedDate}
               handleDateSelect={handleDateSelect}
               calendarRange={calendarRange}
-              isDatePickerOpen={isDatePickerOpen}
-              setIsDatePickerOpen={setIsDatePickerOpen}
               isLoading={isLoading}
               isError={isError}
               dishes={dishes}
               stations={stations}
-              menuAnchor={menuAnchor}
-              setMenuAnchor={setMenuAnchor}
-              scheduleAnchor={scheduleAnchor}
-              setScheduleAnchor={setScheduleAnchor}
               hallEvents={hallEvents}
-              isCompactView={isCompactView}
-              setIsCompactView={setIsCompactView}
-              selectedStation={selectedStation}
-              setSelectedStation={setSelectedStation}
-              showPreferencesOnly={showPreferencesOnly}
-              setShowPreferencesOnly={setShowPreferencesOnly}
             />
 
             <div className="w-full">
               <DishesView
-                isCompactView={isCompactView}
                 stations={stations}
                 activeStation={activeStation}
                 isLoading={isLoading}
                 isError={isError}
                 error={error as TRPCClientErrorLike<AppRouter> | null}
                 hallData={hallData}
-                showPreferencesOnly={showPreferencesOnly}
               />
             </div>
           </div>

--- a/apps/next/src/context/useRestaurantUIStore.ts
+++ b/apps/next/src/context/useRestaurantUIStore.ts
@@ -1,0 +1,59 @@
+import { create } from "zustand";
+
+/**
+ * UI state for the restaurant page — period/station selection, view toggles,
+ * popover anchors, and date picker open state.
+ *
+ * Stored in Zustand so all sub-components (tabs, filters, mobile actions) can
+ * read and update this without prop drilling through RestaurantControls.
+ */
+interface RestaurantUIState {
+  // Meal period
+  selectedPeriod: string;
+  setSelectedPeriod: (period: string) => void;
+
+  // Station
+  selectedStation: string;
+  setSelectedStation: (station: string) => void;
+
+  // View mode
+  isCompactView: boolean;
+  setIsCompactView: (isCompact: boolean) => void;
+
+  // Preferences filter
+  showPreferencesOnly: boolean;
+  setShowPreferencesOnly: (show: boolean) => void;
+
+  // Date picker open state
+  isDatePickerOpen: boolean;
+  setIsDatePickerOpen: (isOpen: boolean) => void;
+
+  // Popover anchors (not serialisable — not persisted)
+  menuAnchor: HTMLElement | null;
+  setMenuAnchor: (el: HTMLElement | null) => void;
+  scheduleAnchor: HTMLElement | null;
+  setScheduleAnchor: (el: HTMLElement | null) => void;
+}
+
+export const useRestaurantUIStore = create<RestaurantUIState>()((set) => ({
+  selectedPeriod: "",
+  setSelectedPeriod: (period) => set({ selectedPeriod: period }),
+
+  selectedStation: "",
+  setSelectedStation: (station) => set({ selectedStation: station }),
+
+  isCompactView: false,
+  setIsCompactView: (isCompact) => set({ isCompactView: isCompact }),
+
+  showPreferencesOnly: false,
+  setShowPreferencesOnly: (show) => set({ showPreferencesOnly: show }),
+
+  isDatePickerOpen: false,
+  setIsDatePickerOpen: (isOpen) => set({ isDatePickerOpen: isOpen }),
+
+  menuAnchor: null,
+  setMenuAnchor: (el) => set({ menuAnchor: el }),
+
+  scheduleAnchor: null,
+  setScheduleAnchor: (el) => set({ scheduleAnchor: el }),
+}));

--- a/apps/next/src/hooks/useRestaurantPage.ts
+++ b/apps/next/src/hooks/useRestaurantPage.ts
@@ -33,11 +33,7 @@ function getCurrentPeriod(
   return Object.keys(periods)[0];
 }
 
-/**
- * Layout-level data returned to RestaurantPage.
- * UI state (period/station selection, toggles, anchors) is no longer threaded
- * through here — components read it directly from useRestaurantUIStore.
- */
+/** All derived state and data needed to render the restaurant page. */
 export interface UseRestaurantPageResult {
   hallData: FormattedRestaurantInfo | undefined;
   isLoading: boolean;
@@ -59,9 +55,8 @@ export interface UseRestaurantPageResult {
 }
 
 /**
- * Handles data fetching, period/station auto-selection, and store syncing.
- * UI state lives in `useRestaurantUIStore` and is consumed directly by
- * sub-components — nothing is prop-drilled through RestaurantControls.
+ * Encapsulates all state, data-fetching, and derived values for the restaurant
+ * page so that `RestaurantPage` can remain a pure layout component.
  */
 export function useRestaurantPage(hall: HallEnum): UseRestaurantPageResult {
   const { selectedDate, setSelectedDate } = useDate();

--- a/apps/next/src/hooks/useRestaurantPage.ts
+++ b/apps/next/src/hooks/useRestaurantPage.ts
@@ -9,6 +9,7 @@ import {
   useHallDerived,
   useRestaurantStore,
 } from "@/context/useRestaurantStore";
+import { useRestaurantUIStore } from "@/context/useRestaurantUIStore";
 import { isSameDay } from "@/utils/funcs";
 import { trpc } from "@/utils/trpc";
 import type { HallStatusEnum } from "@/utils/types";
@@ -32,81 +33,55 @@ function getCurrentPeriod(
   return Object.keys(periods)[0];
 }
 
-/** All derived state and data needed to render the restaurant page. */
+/**
+ * Layout-level data returned to RestaurantPage.
+ * UI state (period/station selection, toggles, anchors) is no longer threaded
+ * through here — components read it directly from useRestaurantUIStore.
+ */
 export interface UseRestaurantPageResult {
-  // Data / loading
   hallData: FormattedRestaurantInfo | undefined;
   isLoading: boolean;
   isError: boolean;
   error: unknown;
   hallEvents: Event[];
-
-  // Period / station selection
   periods: string[];
-  selectedPeriod: string;
-  setSelectedPeriod: (period: string) => void;
-  selectedStation: string;
-  setSelectedStation: (station: string) => void;
   activeStation: Station | undefined;
   stations: Station[];
   dishes: DishWithRating[];
-
-  // View toggles
-  isCompactView: boolean;
-  setIsCompactView: (isCompact: boolean) => void;
-  showPreferencesOnly: boolean;
-  setShowPreferencesOnly: (show: boolean) => void;
-
-  // Date
-  selectedDate: Date | undefined;
-  handleDateSelect: (date: Date | undefined) => void;
   calendarRange: CalendarRange | null;
-  isDatePickerOpen: boolean;
-  setIsDatePickerOpen: (isOpen: boolean) => void;
   displayDate: Date;
-
-  // Popover anchors
-  menuAnchor: HTMLElement | null;
-  setMenuAnchor: (el: HTMLElement | null) => void;
-  scheduleAnchor: HTMLElement | null;
-  setScheduleAnchor: (el: HTMLElement | null) => void;
-
-  // Derived hall status
   derivedHallStatus: HallStatusEnum;
   openTime: Date | null | undefined;
   closeTime: Date | null | undefined;
   availablePeriodTimes: Record<string, [Date, Date] | null> | undefined;
+  selectedDate: Date | undefined;
+  handleDateSelect: (date: Date | undefined) => void;
 }
 
 /**
- * Encapsulates all state, data-fetching, and derived values for the restaurant
- * page so that `RestaurantPage` can remain a pure layout component.
+ * Handles data fetching, period/station auto-selection, and store syncing.
+ * UI state lives in `useRestaurantUIStore` and is consumed directly by
+ * sub-components — nothing is prop-drilled through RestaurantControls.
  */
 export function useRestaurantPage(hall: HallEnum): UseRestaurantPageResult {
   const { selectedDate, setSelectedDate } = useDate();
   const today = useRestaurantStore((s) => s.today);
   const setHallInputs = useRestaurantStore((s) => s.setInputs);
 
-  // --- UI state ---
-  const [showPreferencesOnly, setShowPreferencesOnly] = useState(false);
+  // Read period/station from the shared UI store (written by auto-selection
+  // effects below; also written directly by sub-components on user interaction)
+  const selectedPeriod = useRestaurantUIStore((s) => s.selectedPeriod);
+  const setSelectedPeriod = useRestaurantUIStore((s) => s.setSelectedPeriod);
+  const selectedStation = useRestaurantUIStore((s) => s.selectedStation);
+  const setSelectedStation = useRestaurantUIStore((s) => s.setSelectedStation);
+
+  // calendarRange is query-derived config, not user state — kept local
   const [calendarRange, setCalendarRange] = useState<CalendarRange | null>(
     null,
   );
-  const [selectedPeriod, setSelectedPeriod] = useState("");
-  const [selectedStation, setSelectedStation] = useState("");
-  const [isCompactView, setIsCompactView] = useState(false);
-  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
-  const [scheduleAnchor, setScheduleAnchor] = useState<HTMLElement | null>(
-    null,
-  );
-  const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
-
-  // --- Calendar range ---
   const { data: dateRes } = trpc.pickableDates.useQuery();
   useEffect(() => {
-    if (dateRes) {
-      setCalendarRange(dateRes);
-    }
+    if (dateRes) setCalendarRange(dateRes);
   }, [dateRes]);
 
   const handleDateSelect = (newDateFromPicker: Date | undefined) => {
@@ -133,11 +108,9 @@ export function useRestaurantPage(hall: HallEnum): UseRestaurantPageResult {
     { staleTime: 2 * 60 * 60 * 1000 },
   );
 
-  // Normalise to undefined when loading or errored
   const hallData: FormattedRestaurantInfo | undefined =
     !isLoading && !isError ? data : undefined;
 
-  // --- Sync hall inputs to store ---
   useEffect(() => {
     if (hallData && selectedDate) {
       setHallInputs({ hallData, selectedDate, restaurant: restaurantId });
@@ -178,9 +151,7 @@ export function useRestaurantPage(hall: HallEnum): UseRestaurantPageResult {
   // --- Auto-select period ---
   useEffect(() => {
     if (!selectedDate || periods.length === 0) {
-      if (selectedPeriod !== "") {
-        setSelectedPeriod("");
-      }
+      if (selectedPeriod !== "") setSelectedPeriod("");
       return;
     }
 
@@ -196,11 +167,16 @@ export function useRestaurantPage(hall: HallEnum): UseRestaurantPageResult {
         selectedDate,
         (availablePeriodTimes ?? {}) as Record<string, [Date, Date]>,
       );
-      if (current !== selectedPeriod) {
-        setSelectedPeriod(current);
-      }
+      if (current !== selectedPeriod) setSelectedPeriod(current);
     }
-  }, [availablePeriodTimes, periods, selectedDate, selectedPeriod, today]);
+  }, [
+    availablePeriodTimes,
+    periods,
+    selectedDate,
+    selectedPeriod,
+    today,
+    setSelectedPeriod,
+  ]);
 
   // --- Derived menu / stations / dishes ---
   const currentMenu = useMemo(
@@ -216,19 +192,16 @@ export function useRestaurantPage(hall: HallEnum): UseRestaurantPageResult {
   // --- Auto-select station ---
   useEffect(() => {
     if (stations.length === 0) {
-      if (selectedStation !== "") {
-        setSelectedStation("");
-      }
+      if (selectedStation !== "") setSelectedStation("");
       return;
     }
 
-    const firstStation = stations[0].name.toLowerCase();
     const isValid = stations.some(
       (s) => s.name.toLowerCase() === selectedStation,
     );
 
-    if (!isValid) setSelectedStation(firstStation);
-  }, [selectedStation, stations]);
+    if (!isValid) setSelectedStation(stations[0].name.toLowerCase());
+  }, [selectedStation, stations, setSelectedStation]);
 
   const activeStation =
     stations.find((s) => s.name.toLowerCase() === selectedStation) ??
@@ -243,30 +216,16 @@ export function useRestaurantPage(hall: HallEnum): UseRestaurantPageResult {
     error,
     hallEvents,
     periods,
-    selectedPeriod,
-    setSelectedPeriod,
-    selectedStation,
-    setSelectedStation,
     activeStation,
     stations,
     dishes,
-    isCompactView,
-    setIsCompactView,
-    showPreferencesOnly,
-    setShowPreferencesOnly,
-    selectedDate,
-    handleDateSelect,
     calendarRange,
-    isDatePickerOpen,
-    setIsDatePickerOpen,
     displayDate: selectedDate ?? today,
-    menuAnchor,
-    setMenuAnchor,
-    scheduleAnchor,
-    setScheduleAnchor,
     derivedHallStatus,
     openTime,
     closeTime,
     availablePeriodTimes,
+    selectedDate,
+    handleDateSelect,
   };
 }

--- a/apps/next/src/hooks/useRestaurantPage.ts
+++ b/apps/next/src/hooks/useRestaurantPage.ts
@@ -1,0 +1,272 @@
+"use client";
+
+import type { FormattedRestaurantInfo, Station } from "@api/index";
+import type { DishWithRating, Event } from "@peterplate/validators";
+import { useEffect, useMemo, useState } from "react";
+import type { CalendarRange } from "@/components/ui/toolbar";
+import { useDate } from "@/context/date-context";
+import {
+  useHallDerived,
+  useRestaurantStore,
+} from "@/context/useRestaurantStore";
+import { isSameDay } from "@/utils/funcs";
+import { trpc } from "@/utils/trpc";
+import type { HallStatusEnum } from "@/utils/types";
+import { HallEnum } from "@/utils/types";
+
+/**
+ * Returns the current meal period key for a given date by checking which period
+ * window the date falls within. Falls back to the first period if none match.
+ */
+function getCurrentPeriod(
+  selectedDate: Date,
+  periods: Record<string, [Date, Date]>,
+): string {
+  for (const key in periods) {
+    const periodBegin: Date = periods[key][0];
+    const periodEnd: Date = periods[key][1];
+
+    if (selectedDate >= periodBegin && selectedDate <= periodEnd) return key;
+  }
+
+  return Object.keys(periods)[0];
+}
+
+/** All derived state and data needed to render the restaurant page. */
+export interface UseRestaurantPageResult {
+  // Data / loading
+  hallData: FormattedRestaurantInfo | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+  hallEvents: Event[];
+
+  // Period / station selection
+  periods: string[];
+  selectedPeriod: string;
+  setSelectedPeriod: (period: string) => void;
+  selectedStation: string;
+  setSelectedStation: (station: string) => void;
+  activeStation: Station | undefined;
+  stations: Station[];
+  dishes: DishWithRating[];
+
+  // View toggles
+  isCompactView: boolean;
+  setIsCompactView: (isCompact: boolean) => void;
+  showPreferencesOnly: boolean;
+  setShowPreferencesOnly: (show: boolean) => void;
+
+  // Date
+  selectedDate: Date | undefined;
+  handleDateSelect: (date: Date | undefined) => void;
+  calendarRange: CalendarRange | null;
+  isDatePickerOpen: boolean;
+  setIsDatePickerOpen: (isOpen: boolean) => void;
+  displayDate: Date;
+
+  // Popover anchors
+  menuAnchor: HTMLElement | null;
+  setMenuAnchor: (el: HTMLElement | null) => void;
+  scheduleAnchor: HTMLElement | null;
+  setScheduleAnchor: (el: HTMLElement | null) => void;
+
+  // Derived hall status
+  derivedHallStatus: HallStatusEnum;
+  openTime: Date | null | undefined;
+  closeTime: Date | null | undefined;
+  availablePeriodTimes: Record<string, [Date, Date] | null> | undefined;
+}
+
+/**
+ * Encapsulates all state, data-fetching, and derived values for the restaurant
+ * page so that `RestaurantPage` can remain a pure layout component.
+ */
+export function useRestaurantPage(hall: HallEnum): UseRestaurantPageResult {
+  const { selectedDate, setSelectedDate } = useDate();
+  const today = useRestaurantStore((s) => s.today);
+  const setHallInputs = useRestaurantStore((s) => s.setInputs);
+
+  // --- UI state ---
+  const [showPreferencesOnly, setShowPreferencesOnly] = useState(false);
+  const [calendarRange, setCalendarRange] = useState<CalendarRange | null>(
+    null,
+  );
+  const [selectedPeriod, setSelectedPeriod] = useState("");
+  const [selectedStation, setSelectedStation] = useState("");
+  const [isCompactView, setIsCompactView] = useState(false);
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const [scheduleAnchor, setScheduleAnchor] = useState<HTMLElement | null>(
+    null,
+  );
+  const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
+
+  // --- Calendar range ---
+  const { data: dateRes } = trpc.pickableDates.useQuery();
+  useEffect(() => {
+    if (dateRes) {
+      setCalendarRange(dateRes);
+    }
+  }, [dateRes]);
+
+  const handleDateSelect = (newDateFromPicker: Date | undefined) => {
+    if (newDateFromPicker) {
+      const todayLocal = new Date();
+      if (
+        newDateFromPicker.getFullYear() === todayLocal.getFullYear() &&
+        newDateFromPicker.getMonth() === todayLocal.getMonth() &&
+        newDateFromPicker.getDate() === todayLocal.getDate()
+      ) {
+        setSelectedDate(new Date());
+      } else {
+        setSelectedDate(newDateFromPicker);
+      }
+    } else {
+      setSelectedDate(undefined);
+    }
+  };
+
+  // --- Restaurant data ---
+  const restaurantId = hall === HallEnum.ANTEATERY ? "anteatery" : "brandywine";
+  const { data, isLoading, isError, error } = trpc.restaurant.useQuery(
+    { date: selectedDate ?? today, restaurant: restaurantId },
+    { staleTime: 2 * 60 * 60 * 1000 },
+  );
+
+  // Normalise to undefined when loading or errored
+  const hallData: FormattedRestaurantInfo | undefined =
+    !isLoading && !isError ? data : undefined;
+
+  // --- Sync hall inputs to store ---
+  useEffect(() => {
+    if (hallData && selectedDate) {
+      setHallInputs({ hallData, selectedDate, restaurant: restaurantId });
+    }
+  }, [hallData, selectedDate, setHallInputs, restaurantId]);
+
+  // --- Upcoming events filtered to this hall ---
+  const { data: upcomingEvents = [] } = trpc.event.upcoming.useQuery();
+  const hallEvents = useMemo(
+    () =>
+      [...upcomingEvents]
+        .filter((e) => e.restaurantId === restaurantId)
+        .sort(
+          (a, b) =>
+            (a.start ? new Date(a.start).getTime() : 0) -
+            (b.start ? new Date(b.start).getTime() : 0),
+        ),
+    [upcomingEvents, restaurantId],
+  );
+
+  // --- Hall status / open-close times ---
+  const { availablePeriodTimes, derivedHallStatus, openTime, closeTime } =
+    useHallDerived();
+
+  // --- Period list (sorted by start time) ---
+  const periods = useMemo(() => {
+    const times = availablePeriodTimes ?? {};
+    return Object.keys(times).sort((a, b) => {
+      const startA = times[a]?.[0];
+      const startB = times[b]?.[0];
+      if (startA == null && startB == null) return 0;
+      if (startA == null) return 1;
+      if (startB == null) return -1;
+      return startA <= startB ? -1 : 1;
+    });
+  }, [availablePeriodTimes]);
+
+  // --- Auto-select period ---
+  useEffect(() => {
+    if (!selectedDate || periods.length === 0) {
+      if (selectedPeriod !== "") {
+        setSelectedPeriod("");
+      }
+      return;
+    }
+
+    const isValid = periods.includes(selectedPeriod);
+
+    if (!isSameDay(selectedDate, today) && !selectedPeriod) {
+      setSelectedPeriod(periods[0]);
+      return;
+    }
+
+    if (!isValid) {
+      const current = getCurrentPeriod(
+        selectedDate,
+        (availablePeriodTimes ?? {}) as Record<string, [Date, Date]>,
+      );
+      if (current !== selectedPeriod) {
+        setSelectedPeriod(current);
+      }
+    }
+  }, [availablePeriodTimes, periods, selectedDate, selectedPeriod, today]);
+
+  // --- Derived menu / stations / dishes ---
+  const currentMenu = useMemo(
+    () =>
+      hallData?.periods.find(
+        (period) => period.name.toLowerCase() === selectedPeriod.toLowerCase(),
+      ) ?? null,
+    [hallData, selectedPeriod],
+  );
+
+  const stations: Station[] = currentMenu?.stations ?? [];
+
+  // --- Auto-select station ---
+  useEffect(() => {
+    if (stations.length === 0) {
+      if (selectedStation !== "") {
+        setSelectedStation("");
+      }
+      return;
+    }
+
+    const firstStation = stations[0].name.toLowerCase();
+    const isValid = stations.some(
+      (s) => s.name.toLowerCase() === selectedStation,
+    );
+
+    if (!isValid) setSelectedStation(firstStation);
+  }, [selectedStation, stations]);
+
+  const activeStation =
+    stations.find((s) => s.name.toLowerCase() === selectedStation) ??
+    stations[0];
+
+  const dishes: DishWithRating[] = activeStation?.dishes ?? [];
+
+  return {
+    hallData,
+    isLoading,
+    isError,
+    error,
+    hallEvents,
+    periods,
+    selectedPeriod,
+    setSelectedPeriod,
+    selectedStation,
+    setSelectedStation,
+    activeStation,
+    stations,
+    dishes,
+    isCompactView,
+    setIsCompactView,
+    showPreferencesOnly,
+    setShowPreferencesOnly,
+    selectedDate,
+    handleDateSelect,
+    calendarRange,
+    isDatePickerOpen,
+    setIsDatePickerOpen,
+    displayDate: selectedDate ?? today,
+    menuAnchor,
+    setMenuAnchor,
+    scheduleAnchor,
+    setScheduleAnchor,
+    derivedHallStatus,
+    openTime,
+    closeTime,
+    availablePeriodTimes,
+  };
+}


### PR DESCRIPTION
## Summary

Refactors `RestaurantPage` and its supporting components to improve separation of concerns, eliminate prop drilling, and improve type safety.

---

### Problem

`RestaurantPage` was a 326-line monolith managing all state internally, then threading 22 props through `RestaurantControls` down to its children. Every UI state change (period selection, view toggle, popover open) required a prop at every level of the tree.

### Solution

**Two-commit approach:**

#### 1. Extract `useRestaurantPage` hook
Move data-fetching and derived logic out of the component into a dedicated hook so `RestaurantPage` becomes a pure layout component.

#### 2. Add `useRestaurantUIStore` (Zustand)
All interactive UI state now lives in a Zustand store. Sub-components subscribe to it directly — nothing flows through `RestaurantControls` as props anymore.

---

### Changes

#### `context/useRestaurantUIStore.ts` (new)
Zustand store holding: `selectedPeriod`, `selectedStation`, `isCompactView`, `showPreferencesOnly`, `isDatePickerOpen`, `menuAnchor`, `scheduleAnchor`.

#### `hooks/useRestaurantPage.ts` (new)
Handles data fetching, period/station auto-selection, and store syncing. Reads `selectedPeriod`/`selectedStation` from the UI store for auto-selection effects. Returns only query-derived data (`hallData`, `stations`, `hallEvents`, etc.) — not UI state.

#### `restaurant-page.tsx`
Now a pure layout component (~120 lines vs 326 before). Delegates all logic to `useRestaurantPage`. Passes only query-derived data to children.

#### `restaurant-controls.tsx`
Props reduced from 22 → 13. All UI state props removed — sub-components pull from the store directly.

#### `header/restaurant-filters.tsx`
Props reduced from 12 → 6. Reads `selectedPeriod`, `isDatePickerOpen`, `showPreferencesOnly` (and setters) from `useRestaurantUIStore`.

#### `header/desktop-tabs.tsx`
Props reduced from 8 → 4. Reads `selectedStation`, `isCompactView` (and setters) from the store.

#### `header/mobile-actions.tsx`
Props reduced from 13 → 6. Reads `menuAnchor`, `scheduleAnchor`, `isCompactView`, `setSelectedStation` from the store. Also fixes `event.shortDescription` → `event.description` (field doesn't exist on `Event` from `@peterplate/validators`).

#### `dishes-view.tsx`
Props reduced from 8 → 6. Reads `isCompactView` and `showPreferencesOnly` from the store. Relaxes `activeStation` to `Station | undefined` to correctly reflect loading state.