### PR TITLE
714/refactor-food-cards

### DIFF
--- a/apps/next/src/components/ui/card/food-card-shell.tsx
+++ b/apps/next/src/components/ui/card/food-card-shell.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { Dialog, Drawer } from "@mui/material";
+import type { DishWithRating } from "@peterplate/validators";
+import { useState } from "react";
+import { useSnackbarStore } from "@/context/useSnackbar";
+import { useUserStore } from "@/context/useUserStore";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { formatFoodName } from "@/utils/funcs";
+import { trpc } from "@/utils/trpc";
+import FoodDialogContent from "../food-dialog-content";
+import FoodDrawerContent from "../food-drawer-content";
+
+interface FoodCardShellProps {
+  dish: DishWithRating;
+  restaurant?: "anteatery" | "brandywine";
+  children: (
+    handleOpen: () => void,
+    handleAddToMealTracker: (e: React.MouseEvent) => void,
+    isPending: boolean,
+  ) => React.ReactNode;
+}
+
+export default function FoodCardShell({
+  dish,
+  restaurant,
+  children,
+}: FoodCardShellProps) {
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+  const [open, setOpen] = useState(false);
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+  const userId = useUserStore((s) => s.userId);
+  const utils = trpc.useUtils();
+  const { showSnackbar } = useSnackbarStore();
+
+  const logMealMutation = trpc.nutrition.logMeal.useMutation({
+    onSuccess: () => {
+      showSnackbar(`Added ${formatFoodName(dish.name)} to your log`, "success");
+      utils.nutrition.invalidate();
+    },
+    onError: (error) => {
+      console.error(error.message);
+    },
+  });
+
+  const handleAddToMealTracker = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!userId) {
+      showSnackbar("Login to track meals!", "error");
+      return;
+    }
+    logMealMutation.mutate({
+      dishId: dish.id,
+      userId,
+      dishName: dish.name,
+      servings: 1,
+    });
+  };
+
+  const sharedSx = {
+    width: "460px",
+    maxWidth: "90vw",
+    margin: 2,
+    padding: 0,
+    overflow: "hidden",
+    borderRadius: "16px",
+  };
+
+  return (
+    <>
+      {children(handleOpen, handleAddToMealTracker, logMealMutation.isPending)}
+      {isDesktop ? (
+        <Dialog
+          open={open}
+          onClose={handleClose}
+          maxWidth={false}
+          slotProps={{
+            paper: {
+              sx: {
+                ...sharedSx,
+                maxHeight: "90vh",
+                display: "flex",
+                flexDirection: "column",
+              },
+            },
+          }}
+        >
+          <FoodDialogContent
+            dish={dish}
+            restaurant={restaurant}
+            onAddToMealTracker={handleAddToMealTracker}
+            isAddingToMealTracker={logMealMutation.isPending}
+          />
+        </Dialog>
+      ) : (
+        <Drawer
+          anchor="bottom"
+          open={open}
+          onClose={handleClose}
+          slotProps={{
+            paper: {
+              sx: {
+                ...sharedSx,
+                maxHeight: "85vh",
+                display: "flex",
+                flexDirection: "column",
+              },
+            },
+          }}
+          sx={{
+            "& .MuiDrawer-paper": {
+              borderTopLeftRadius: "10px",
+              borderTopRightRadius: "10px",
+              marginTop: "96px",
+              height: "auto",
+              maxHeight: "85vh",
+            },
+          }}
+        >
+          <FoodDrawerContent
+            dish={dish}
+            restaurant={restaurant}
+            onAddToMealTracker={handleAddToMealTracker}
+            isAddingToMealTracker={logMealMutation.isPending}
+          />
+        </Drawer>
+      )}
+    </>
+  );
+}

--- a/apps/next/src/components/ui/card/food-card.tsx
+++ b/apps/next/src/components/ui/card/food-card.tsx
@@ -2,20 +2,17 @@
 
 import { Restaurant, StarBorder } from "@mui/icons-material";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
-import { Card, CardContent, Dialog, Drawer, Typography } from "@mui/material";
+import { Card, CardContent, Typography } from "@mui/material";
 import type { DishWithRating } from "@peterplate/validators";
 import Image from "next/image";
 import React from "react";
-import { useSnackbarStore } from "@/context/useSnackbar";
 import { useUserStore } from "@/context/useUserStore";
-import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { getDietaryConflicts } from "@/utils/dietary";
 import { formatFoodName, getFoodIcon } from "@/utils/funcs";
 import { trpc } from "@/utils/trpc";
 import { cn } from "@/utils/tw";
 import Favorite from "../favorite";
-import FoodDialogContent from "../food-dialog-content";
-import FoodDrawerContent from "../food-drawer-content";
+import FoodCardShell from "./food-card-shell";
 
 /** Handler for "Add to meal tracker" used by card, dialog, and drawer. */
 export type OnAddToMealTracker = (e: React.MouseEvent) => void;
@@ -267,43 +264,9 @@ export default function FoodCard({
   className,
   ...dish
 }: FoodCardProps): React.JSX.Element {
-  const isDesktop = useMediaQuery("(min-width: 768px)");
-  const [open, setOpen] = React.useState(false);
-  const userId = useUserStore((s) => s.userId);
-
-  const utils = trpc.useUtils();
-  const { showSnackbar } = useSnackbarStore();
-
-  const logMealMutation = trpc.nutrition.logMeal.useMutation({
-    onSuccess: () => {
-      showSnackbar(`Added ${formatFoodName(dish.name)} to your log`, "success");
-      utils.nutrition.invalidate();
-    },
-    onError: (error) => {
-      console.error(error.message);
-    },
-  });
-
-  const handleOpen = () => setOpen(true);
-  const handleClose = () => setOpen(false);
-
-  const handleAddToMealTracker = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (!userId) {
-      showSnackbar("Login to track meals!", "error");
-      return;
-    }
-    logMealMutation.mutate({
-      dishId: dish.id,
-      userId,
-      dishName: dish.name,
-      servings: 1,
-    });
-  };
-
-  if (isDesktop)
-    return (
-      <>
+  return (
+    <FoodCardShell dish={dish} restaurant={restaurant}>
+      {(handleOpen, handleAddToMealTracker) => (
         <FoodCardContent
           {...{
             dish,
@@ -317,85 +280,7 @@ export default function FoodCard({
           onAddToMealTracker={handleAddToMealTracker}
           onClick={handleOpen}
         />
-        <Dialog
-          open={open}
-          onClose={handleClose}
-          maxWidth={false}
-          slotProps={{
-            paper: {
-              sx: {
-                width: "460px",
-                maxWidth: "90vw",
-                maxHeight: "90vh",
-                margin: 2,
-                padding: 0,
-                overflow: "hidden",
-                display: "flex",
-                flexDirection: "column",
-                borderRadius: "16px",
-              },
-            },
-          }}
-        >
-          <FoodDialogContent
-            {...{ dish, restaurant }}
-            onAddToMealTracker={handleAddToMealTracker}
-            isAddingToMealTracker={logMealMutation.isPending}
-          />
-        </Dialog>
-      </>
-    );
-  else
-    return (
-      <>
-        <FoodCardContent
-          {...{
-            dish,
-            restaurant,
-            isFavorited,
-            onToggleFavorite,
-            isCompact,
-            className,
-          }}
-          favoriteDisabled={favoriteIsLoading}
-          onAddToMealTracker={handleAddToMealTracker}
-          onClick={handleOpen}
-        />
-        <Drawer
-          anchor="bottom"
-          open={open}
-          onClose={handleClose}
-          slotProps={{
-            paper: {
-              sx: {
-                width: "460px",
-                maxWidth: "90vw",
-                maxHeight: "85vh",
-                margin: 2,
-                padding: 0,
-                overflow: "hidden",
-                display: "flex",
-                flexDirection: "column",
-                borderRadius: "16px",
-              },
-            },
-          }}
-          sx={{
-            "& .MuiDrawer-paper": {
-              borderTopLeftRadius: "10px",
-              borderTopRightRadius: "10px",
-              marginTop: "96px",
-              height: "auto",
-              maxHeight: "85vh",
-            },
-          }}
-        >
-          <FoodDrawerContent
-            {...{ dish, restaurant }}
-            onAddToMealTracker={handleAddToMealTracker}
-            isAddingToMealTracker={logMealMutation.isPending}
-          />
-        </Drawer>
-      </>
-    );
+      )}
+    </FoodCardShell>
+  );
 }

--- a/apps/next/src/components/ui/card/popular-dish-card.tsx
+++ b/apps/next/src/components/ui/card/popular-dish-card.tsx
@@ -1,15 +1,16 @@
+"use client";
+
 import { Star } from "@mui/icons-material";
-import { Box, Card, Dialog, Drawer, Typography } from "@mui/material";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import { Box, Card, Typography } from "@mui/material";
 import type { DishWithRating } from "@peterplate/validators";
 import Image from "next/image";
-import React, { useState } from "react";
-import { useSnackbarStore } from "@/context/useSnackbar";
+import React from "react";
 import { useUserStore } from "@/context/useUserStore";
-import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { getDietaryConflicts } from "@/utils/dietary";
 import { formatFoodName, getFoodIcon, toTitleCase } from "@/utils/funcs";
 import { trpc } from "@/utils/trpc";
-import FoodDialogContent from "../food-dialog-content";
-import FoodDrawerContent from "../food-drawer-content";
+import FoodCardShell from "./food-card-shell";
 
 interface PopularDishCardContentProps
   extends React.HTMLAttributes<HTMLDivElement> {
@@ -27,15 +28,34 @@ const PopularDishCardContent = React.forwardRef<
   const iconSize = compact ? 16 : 24;
   const descSize = compact ? "text-[8px]" : "text-[10px]";
 
+  const { userId } = useUserStore();
+
   const { data: ratingData } = trpc.dish.getAverageRating.useQuery(
     { dishId: dish.id },
     { staleTime: 5 * 60 * 1000 },
   );
   const averageRating = ratingData?.averageRating ?? 0;
 
+  const { data: allergies } = trpc.allergy.getAllergies.useQuery(
+    { userId: userId ?? "" },
+    { staleTime: Infinity },
+  );
+
+  const { data: preferences } = trpc.preference.getDietaryPreferences.useQuery(
+    { userId: userId ?? "" },
+    { staleTime: Infinity },
+  );
+
+  const violations = getDietaryConflicts(
+    dish.dietRestriction,
+    preferences ?? [],
+    allergies ?? [],
+  );
+  const conflictsWithUserPrefs = violations.length > 0;
+
   return (
     <Card
-      className="w-full h-full min-h-[210px] flex flex-col rounded-xl border border-neutral-200 dark:border-neutral-700 overflow-hidden shadow-sm hover:shadow-md transition cursor-pointer text-left bg-transparent p-0"
+      className={`w-full h-full min-h-[210px] flex flex-col rounded-xl border border-neutral-200 dark:border-neutral-700 overflow-hidden shadow-sm hover:shadow-md transition cursor-pointer text-left bg-transparent p-0 ${conflictsWithUserPrefs ? "opacity-70" : ""}`}
       onClick={onClick}
       ref={ref}
     >
@@ -64,6 +84,12 @@ const PopularDishCardContent = React.forwardRef<
           color="primary"
         >
           {formatFoodName(dish.name)}
+          {conflictsWithUserPrefs && (
+            <ErrorOutlineIcon
+              fontSize="inherit"
+              className="ml-1 text-red-600 align-[-0.125em]"
+            />
+          )}
         </Typography>
         <Typography className={`${descSize} mb-1`} color="text.secondary">
           {toTitleCase(restaurant)} • {toTitleCase(stationName)}
@@ -87,118 +113,15 @@ export default function PopularDishCard({
   restaurant,
   stationName,
   compact = false,
-  onClick,
 }: PopularDishCardContentProps): React.JSX.Element {
-  const isDesktop = useMediaQuery("(min-width: 768px)");
-  const [open, setOpen] = useState(false);
-  const handleOpen = () => setOpen(true);
-  const handleClose = () => setOpen(false);
-  const userId = useUserStore((s) => s.userId);
-  const utils = trpc.useUtils();
-  const { showSnackbar } = useSnackbarStore();
-
-  const logMealMutation = trpc.nutrition.logMeal.useMutation({
-    onSuccess: () => {
-      showSnackbar(`Added ${formatFoodName(dish.name)} to your log`, "success");
-      utils.nutrition.invalidate();
-    },
-    onError: (error) => {
-      console.error(error.message);
-    },
-  });
-
-  const handleAddToMealTracker = (e: React.MouseEvent) => {
-    e.stopPropagation();
-
-    if (!userId) {
-      showSnackbar("Login to track meals!", "error");
-      return;
-    }
-
-    logMealMutation.mutate({
-      dishId: dish.id,
-      userId,
-      dishName: dish.name,
-      servings: 1,
-    });
-  };
-
-  if (isDesktop) {
-    return (
-      <>
-        {/* ...When you could do this! */}
+  return (
+    <FoodCardShell dish={dish} restaurant={restaurant}>
+      {(handleOpen) => (
         <PopularDishCardContent
           {...{ dish, restaurant, stationName, compact }}
           onClick={handleOpen}
         />
-        <Dialog
-          open={open}
-          onClose={handleClose}
-          maxWidth={false}
-          slotProps={{
-            paper: {
-              sx: {
-                width: "460px",
-                maxWidth: "90vw",
-                margin: 2,
-                padding: 0,
-                overflow: "hidden",
-                borderRadius: "16px",
-              },
-            },
-          }}
-        >
-          <FoodDialogContent
-            dish={dish}
-            onAddToMealTracker={handleAddToMealTracker}
-            isAddingToMealTracker={logMealMutation.isPending}
-          />
-        </Dialog>
-      </>
-    );
-  } else {
-    return (
-      <>
-        <PopularDishCardContent
-          {...{ dish, restaurant, compact, stationName }}
-          onClick={handleOpen}
-        />
-        <Drawer
-          anchor="bottom"
-          open={open}
-          onClose={handleClose}
-          slotProps={{
-            paper: {
-              sx: {
-                width: "460px",
-                maxWidth: "90vw",
-                maxHeight: "85vh",
-                margin: 2,
-                padding: 0,
-                overflow: "hidden",
-                display: "flex",
-                flexDirection: "column",
-                borderRadius: "16px",
-              },
-            },
-          }}
-          sx={{
-            "& .MuiDrawer-paper": {
-              borderTopLeftRadius: "10px",
-              borderTopRightRadius: "10px",
-              marginTop: "96px",
-              height: "auto",
-              maxHeight: "85vh",
-            },
-          }}
-        >
-          <FoodDrawerContent
-            dish={dish}
-            onAddToMealTracker={handleAddToMealTracker}
-            isAddingToMealTracker={logMealMutation.isPending}
-          />
-        </Drawer>
-      </>
-    );
-  }
+      )}
+    </FoodCardShell>
+  );
 }


### PR DESCRIPTION
## Summary

Refactors `popular-dish-card.tsx` and `food-card.tsx` to remove duplicated modal/mutation logic by extracting it into a new shared `FoodCardShell` component. Also adds dietary restriction/preference conflict indicators to popular dish cards on the home screen, which previously only showed on restaurant page cards.

## Changes

- `food-card-shell.tsx` (new) — shared wrapper that owns `isDesktop`, open/close state, `logMealMutation`, `handleAddToMealTracker`, and the `Dialog`/`Drawer` JSX. Uses a render prop (`children`) so each card passes in its own content while the shell handles the rest
- `food-card.tsx` — removed all duplicated modal/mutation logic, now wraps `FoodCardContent` in `FoodCardShell`
- `popular-dish-card.tsx` — same refactor as above; added `getAllergies`, `getDietaryPreferences`, and `getDietaryConflicts` so conflicting dishes now show a red warning icon and `opacity-70` on the home screen

## Testing Instructions

- Go to `/anteatery` or `/brandywine` and click a food card — dialog (desktop) or drawer (mobile) should open as before
- Add a dish to meal tracker from the dialog — snackbar should confirm
- On the home screen, dishes that conflict with your dietary preferences should now show a red warning icon and reduced opacity
- Check both light and dark mode look correct on both card types

Closes #714