### PR TITLE
fix: 🐛 keep dining hall open/closed status live (#501)

### DIFF
--- a/apps/next/src/context/useRestaurantStore.ts
+++ b/apps/next/src/context/useRestaurantStore.ts
@@ -1,6 +1,6 @@
 import type { FormattedRestaurantInfo } from "@api/index";
 import { create } from "zustand";
-import { militaryToStandard } from "@/utils/funcs";
+import { isSameDay, militaryToStandard } from "@/utils/funcs";
 import { HallStatusEnum } from "@/utils/types";
 
 interface HallStore {
@@ -8,6 +8,13 @@ interface HallStore {
   selectedDate?: Date;
   restaurant?: "anteatery" | "brandywine";
   today: Date;
+  /**
+   * The current wall-clock time. Updated on an interval (see `useRestaurantPage`)
+   * so that the derived open/closed status re-computes while the page is left
+   * open across an open→close transition.
+   */
+  now: Date;
+  setNow: (now: Date) => void;
   setInputs: (input: {
     hallData: FormattedRestaurantInfo;
     selectedDate: Date;
@@ -20,13 +27,15 @@ export const useRestaurantStore = create<HallStore>((set) => ({
   selectedDate: undefined,
   restaurant: undefined,
   today: new Date(),
+  now: new Date(),
+  setNow: (now) => set({ now }),
   setInputs: ({ hallData, selectedDate, restaurant }) =>
     set({ hallData, selectedDate, restaurant }),
 }));
 
 export const useHallDerived = () =>
   useRestaurantStore((state) => {
-    const { hallData, selectedDate, today } = state;
+    const { hallData, selectedDate, today, now } = state;
 
     const availablePeriodTimes: Record<string, [Date, Date]> = {};
     let derivedHallStatus = HallStatusEnum.CLOSED;
@@ -71,10 +80,16 @@ export const useHallDerived = () =>
     openTime = earliestOpen ?? undefined;
     closeTime = latestClose ?? undefined;
 
+    // When the user is viewing today's menu, compare against the live `now` so
+    // the status flips from Open to Closed (and vice versa) as the clock passes
+    // an open/close boundary — even if the page is just left open. For any other
+    // selected day, keep using the selected date so the result is unchanged.
+    const referenceTime = isSameDay(selectedDate, now) ? now : selectedDate;
+
     if (!openTime || !closeTime) derivedHallStatus = HallStatusEnum.ERROR;
     else if (today.getDay() !== openTime?.getDay())
       derivedHallStatus = HallStatusEnum.PREVIEW;
-    else if (selectedDate >= openTime && selectedDate < closeTime)
+    else if (referenceTime >= openTime && referenceTime < closeTime)
       derivedHallStatus = HallStatusEnum.OPEN;
     else derivedHallStatus = HallStatusEnum.CLOSED;
 

--- a/apps/next/src/hooks/useRestaurantPage.ts
+++ b/apps/next/src/hooks/useRestaurantPage.ts
@@ -62,6 +62,15 @@ export function useRestaurantPage(hall: HallEnum): UseRestaurantPageResult {
   const { selectedDate, setSelectedDate } = useDate();
   const today = useRestaurantStore((s) => s.today);
   const setHallInputs = useRestaurantStore((s) => s.setInputs);
+  const setNow = useRestaurantStore((s) => s.setNow);
+
+  // Keep a live clock in the store while a restaurant page is mounted so the
+  // derived open/closed status updates on its own when the hall opens or closes,
+  // without the user having to refresh the page (#501).
+  useEffect(() => {
+    const intervalId = setInterval(() => setNow(new Date()), 30_000);
+    return () => clearInterval(intervalId);
+  }, [setNow]);
 
   // Read period/station from the shared UI store (written by auto-selection
   // effects below; also written directly by sub-components on user interaction)


### PR DESCRIPTION
## Summary
The dining hall's Open/Closed status was derived from a `selectedDate` that is frozen when the app loads and a `today` captured once when the restaurant store is created, and nothing re-derived it on a timer. If you left a hall page open across an open→close transition, the status stayed stale (e.g. still showing **Open** after the hall had actually closed) until you refreshed the page.

This adds a live `now` clock to the restaurant store that ticks every 30 seconds while a hall page is mounted, and uses it as the reference time for the open/close window **when you're viewing today**. Any other selected day keeps comparing against the selected date, so its behavior is unchanged.

## Changes
- [ ] `useRestaurantStore`: add a `now: Date` field (plus `setNow`) to the store
- [ ] `useHallDerived`: compare the open/close window against the live `now` when the selected day is today (falls back to `selectedDate` for any other day, preserving existing behavior)
- [ ] `useRestaurantPage`: tick `now` every 30s via `setInterval` while a hall page is mounted, cleaning up the interval on unmount

### Testing Instructions
No local setup changes are needed beyond the usual dev environment.
1. Open the Anteatery or Brandywine page a few minutes before a meal-period boundary (an open→close or close→open time).
2. Leave the page open — do **not** refresh — and watch the status indicator (the colored dot + "Open"/"Closed" text, shown in the desktop controls and the mobile hero).
3. When the clock passes the boundary, the status should flip on its own within ~30s.
4. Sanity check that selecting a non-today date still shows its menu as before, and that selecting today reflects the current open/closed state.

Closes #501