### PR TITLE
729/Restaurant Page Headers and Options Updates

### DIFF
--- a/apps/next/src/components/ui/restaurant/dishes-view.tsx
+++ b/apps/next/src/components/ui/restaurant/dishes-view.tsx
@@ -74,12 +74,12 @@ export function DishesView({
               id={station.name.toLowerCase()}
               className="[&_#food-scroll]:h-auto [&_#food-scroll]:overflow-y-visible mb-8 scroll-mt-4"
             >
-              <div className="mb-4">
+              <div className="mt-2 mb-4 !bg-sky-700/20 dark:!bg-[#46566a] !rounded-lg !p-2">
                 <Typography
                   variant="h5"
-                  fontWeight={700}
-                  color="text.primary"
-                  sx={{ fontSize: "1.875rem" }}
+                  fontWeight={650}
+                  color="primary"
+                  sx={{ fontSize: "1.5rem" }}
                 >
                   {toTitleCase(station.name)}
                 </Typography>
@@ -97,12 +97,12 @@ export function DishesView({
         : // Normal View: Render active station
           activeStation && (
             <div className="[&_#food-scroll]:h-auto [&_#food-scroll]:overflow-y-visible">
-              <div className="mb-4">
+              <div className="mt-2 mb-4 !bg-sky-700/20 dark:!bg-[#46566a] !rounded-lg !p-2">
                 <Typography
                   variant="h5"
-                  fontWeight={700}
-                  color="text.primary"
-                  sx={{ fontSize: "1.875rem" }}
+                  fontWeight={650}
+                  color="primary"
+                  sx={{ fontSize: "1.5rem" }}
                 >
                   {toTitleCase(activeStation.name)}
                 </Typography>

--- a/apps/next/src/components/ui/restaurant/header/desktop-tabs.tsx
+++ b/apps/next/src/components/ui/restaurant/header/desktop-tabs.tsx
@@ -42,7 +42,7 @@ export function DesktopTabs({
             }
             setSelectedStation(val);
           }}
-          className="flex w-full overflow-x-auto no-scrollbar !bg-sky-700/40 dark:!bg-[#46566a] !rounded-lg !p-2 [&_.MuiTabs-flexContainer]:justify-between [&_.MuiTabs-flexContainer]:gap-2 [&_.MuiTabs-indicator]:hidden"
+          className="flex w-full overflow-x-auto no-scrollbar !bg-sky-700/20 dark:!bg-[#46566a] !rounded-lg !p-2 [&_.MuiTabs-flexContainer]:justify-between [&_.MuiTabs-flexContainer]:gap-2 [&_.MuiTabs-indicator]:hidden"
           variant="scrollable"
           scrollButtons={false}
         >
@@ -64,20 +64,18 @@ export function DesktopTabs({
             size="small"
             type="button"
             onClick={() => setIsCompactView(false)}
-            className={`!border-sky-700 dark:!border-blue-300 !normal-case ${!isCompactView ? "!bg-sky-700 !text-white hover:!bg-sky-700 dark:!bg-blue-300 dark:!text-gray-900" : "!bg-white !text-sky-700 hover:!bg-sky-50 dark:!bg-transparent dark:!text-white"}`}
-            startIcon={<MenuIcon className="h-4 w-4" />}
+            className={`!min-w-0 !w-10 !h-10 !p-0 !border-sky-700 dark:!border-blue-300 !normal-case ${!isCompactView ? "!bg-sky-700 !text-white hover:!bg-sky-700 dark:!bg-blue-300 dark:!text-gray-900" : "!bg-white !text-sky-700 hover:!bg-sky-50 dark:!bg-transparent dark:!text-white"}`}
           >
-            Card View
+            <MenuIcon className="h-5 w-5" />
           </Button>
           <Button
             variant="outlined"
             size="small"
             type="button"
             onClick={() => setIsCompactView(true)}
-            className={`!border-sky-700 dark:!border-blue-300 !normal-case ${isCompactView ? "!bg-sky-700 !text-white hover:!bg-sky-700 dark:!bg-blue-300 dark:!text-gray-900" : "!bg-white !text-sky-700 hover:!bg-sky-50 dark:!bg-transparent dark:!text-white"}`}
-            startIcon={<GridView className="h-4 w-4" />}
+            className={`!min-w-0 !w-10 !h-10 !p-0 !border-sky-700 dark:!border-blue-300 !normal-case ${isCompactView ? "!bg-sky-700 !text-white hover:!bg-sky-700 dark:!bg-blue-300 dark:!text-gray-900" : "!bg-white !text-sky-700 hover:!bg-sky-50 dark:!bg-transparent dark:!text-white"}`}
           >
-            Compact View
+            <GridView className="h-5 w-5" />
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
Followed Figma to rework Restaurant page styling. Station headers are recolored and given backgrounds. Buttons for toggling between card and compact views no longer have labels.

## Changes
- [x] Matched Restaurant page station select and station headers to Figma in dishes-view.tsx and desktop-tabs.tsx
- [x] Removed labels from card and compact view toggle buttons in desktop-tabs.tsx

## Questions
I was going to move the view toggle buttons to besides the show preferences only button to match the Figma, but I noticed there were possible rework suggestions so I want to ask about it before making any changes. I’m happy to finish the rest of this PR after the redesign is confirmed.


### Testing Instructions
Go to the Restaurant page and check for both Anteatery and Brandywine that:
- Each station header matches its appearance on the Figma on both card and compact views
- The button for toggling the different views no longer have a label

Closes #729
