### PR TITLE
fix: 🐛 bug with theme refresh

### DIFF
--- a/apps/next/src/components/ui/sidebar/sidebar-content.tsx
+++ b/apps/next/src/components/ui/sidebar/sidebar-content.tsx
@@ -51,10 +51,10 @@ export default function SidebarContent({
   );
 
   const handleSignOut = async () => {
-    const savedTheme = localStorage.getItem("theme");
+    const userTheme = theme ?? localStorage.getItem("theme");
     await signOut();
-    if (savedTheme) {
-      localStorage.setItem("theme", savedTheme);
+    if (userTheme) {
+      localStorage.setItem("theme", userTheme);
     }
     window.location.href = "/";
   };


### PR DESCRIPTION
Old theme was occasionally getting overwritten by null value in the localhost.

## Summary
Will check the theme given by useTheme() hook before grabbing the localStorage theme. Will only use the localStorage theme if the theme isn't already defined.

Closes #750
