### PR TITLE
feat(toolbar): ✨ guest menu for logged-out users

### DIFF
--- a/apps/next/src/components/ui/onboarding.tsx
+++ b/apps/next/src/components/ui/onboarding.tsx
@@ -54,7 +54,7 @@ interface OnboardingContentProps extends React.HTMLAttributes<HTMLDivElement> {
   handleClose: () => void;
 }
 
-const WelcomeView = React.forwardRef<HTMLDivElement>((_, ref) => {
+export const WelcomeView = React.forwardRef<HTMLDivElement>((_, ref) => {
   return (
     <Box
       ref={ref}

--- a/apps/next/src/components/ui/sidebar/sidebar-content.tsx
+++ b/apps/next/src/components/ui/sidebar/sidebar-content.tsx
@@ -69,81 +69,87 @@ export default function SidebarContent({
     >
       {/* Header */}
       <div
-        className={`flex items-start justify-between px-5 p-5 border-b-2 
-        border-gray-300 dark:border-zinc-700`}
+        className={cn(
+          "flex items-start justify-between px-5 border-b-2 border-gray-300 dark:border-zinc-700",
+          user ? "py-5" : "py-2",
+        )}
       >
-        <div className="flex items-center gap-3">
-          <Image
-            src={user?.image || "/peter.webp"}
-            alt="Profile"
-            width={44}
-            height={44}
-            className="rounded-full object-cover"
-          />
-          <div>
-            <Typography variant="body2" fontWeight={600} color="text.primary">
-              {user?.name || "Peter Anteater"}
-            </Typography>
-            <Typography variant="caption" color="text.secondary">
-              {user?.email || "panteater@uci.edu"}
-            </Typography>
+        {user ? (
+          <div className="flex items-center gap-3">
+            <Image
+              src={user.image || "/peter.webp"}
+              alt="Profile"
+              width={44}
+              height={44}
+              className="rounded-full object-cover"
+            />
+            <div>
+              <Typography variant="body2" fontWeight={600} color="text.primary">
+                {user.name || "Peter Anteater"}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {user.email || "panteater@uci.edu"}
+              </Typography>
+            </div>
           </div>
-        </div>
+        ) : (
+          <div />
+        )}
 
         <button
           type="button"
           onClick={onClose}
-          className="rounded-full p-1.5 hover:bg-gray-100 dark:hover:bg-gray-700"
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full hover:bg-gray-100 dark:hover:bg-gray-700"
         >
-          <CloseIcon sx={{ fontSize: 18, color: "text.primary" }} />
+          <CloseIcon sx={{ fontSize: 20, color: "text.primary" }} />
         </button>
       </div>
 
-      <hr className="border-t border-gray-200 dark:border-gray-700 mx-5 mt-4" />
-
       {/* Content */}
       <div className="flex-1 px-5 p-4 space-y-5 border-b-2 border-gray-300 dark:border-zinc-700">
-        {/* Dietary Preferences */}
-        <div>
-          <Typography className="text-sm font-bold text-sky-700 dark:text-accent-primary mb-2">
-            Dietary Preferences
-          </Typography>
+        {/* Dietary Preferences (signed-in users only) */}
+        {user && (
+          <div>
+            <Typography className="text-sm font-bold text-sky-700 dark:text-blue-300 mb-2">
+              Dietary Preferences
+            </Typography>
 
-          <Typography className="text-xs font-semibold text-gray-500 dark:text-zinc-300 mb-1">
-            Restrictions:
-          </Typography>
+            <Typography className="text-xs font-semibold text-gray-500 dark:text-zinc-300 mb-1">
+              Restrictions:
+            </Typography>
 
-          <div className="flex flex-wrap gap-1.5 mb-3">
-            {preferences?.length ? (
-              preferences.map((pref) => (
-                <PrefBadge key={pref} type="restriction" text={pref} />
-              ))
-            ) : (
-              <span className="text-xs text-gray-400 dark:text-zinc-300">
-                None
-              </span>
-            )}
+            <div className="flex flex-wrap gap-1.5 mb-3">
+              {preferences?.length ? (
+                preferences.map((pref) => (
+                  <PrefBadge key={pref} type="restriction" text={pref} />
+                ))
+              ) : (
+                <span className="text-xs text-gray-400 dark:text-zinc-300">
+                  None
+                </span>
+              )}
+            </div>
+
+            <Typography className="text-xs font-semibold text-gray-500 dark:text-zinc-300 mb-1">
+              Allergies:
+            </Typography>
+            <div className="flex flex-wrap gap-1.5">
+              {allergies?.length ? (
+                allergies.map((allergy) => (
+                  <PrefBadge key={allergy} type="allergy" text={allergy} />
+                ))
+              ) : (
+                <span className="text-xs text-gray-400 dark:text-zinc-300">
+                  None
+                </span>
+              )}
+            </div>
           </div>
-
-          <Typography className="text-xs font-semibold text-gray-500 dark:text-zinc-300 mb-1">
-            Allergies:
-          </Typography>
-          <div className="flex flex-wrap gap-1.5">
-            {allergies?.length ? (
-              allergies.map((allergy) => (
-                <PrefBadge key={allergy} type="allergy" text={allergy} />
-              ))
-            ) : (
-              <span className="text-xs text-gray-400 dark:text-zinc-300">
-                None
-              </span>
-            )}
-          </div>
-        </div>
+        )}
 
         {/* Appearance */}
         <div>
-          <Typography className="text-sm font-bold text-sky-700 dark:text-accent-primary mb-2">
+          <Typography className="text-sm font-bold text-sky-700 dark:text-blue-300 mb-2">
             Appearance
           </Typography>
 
@@ -186,7 +192,7 @@ export default function SidebarContent({
                   onClose();
                   onEditPreferencesClick();
                 }}
-                className={`w-full flex items-center gap-3 rounded-lg px-4 py-2 
+                className={`w-full flex items-center gap-3 rounded-lg px-2 py-2 
                   text-sm text-gray-900 dark:text-white hover:bg-gray-100 
                   dark:hover:bg-gray-700 disabled:opacity-50 
                   disabled:cursor-not-allowed disabled:hover:bg-transparent 
@@ -307,7 +313,7 @@ function MenuLink({
     <Link
       href={href}
       onClick={onClick}
-      className={`flex items-center gap-3 rounded-lg px-4 py-2 hover:bg-gray-100
+      className={`flex items-center gap-3 rounded-lg px-2 py-2 hover:bg-gray-100
         dark:hover:bg-gray-700`}
     >
       <Box sx={{ color: "primary.main" }}>{icon}</Box>

--- a/apps/next/src/components/ui/toolbar.tsx
+++ b/apps/next/src/components/ui/toolbar.tsx
@@ -6,6 +6,7 @@ import FavoriteBorder from "@mui/icons-material/FavoriteBorder";
 import HomeRoundedIcon from "@mui/icons-material/HomeRounded";
 import InsertInvitation from "@mui/icons-material/InsertInvitation";
 import ListAltRoundedIcon from "@mui/icons-material/ListAltRounded";
+import LoginIcon from "@mui/icons-material/Login";
 import MenuIcon from "@mui/icons-material/Menu";
 import RestaurantRoundedIcon from "@mui/icons-material/RestaurantRounded";
 import {
@@ -26,10 +27,10 @@ import { usePathname } from "next/navigation";
 import { useTheme } from "next-themes";
 import type { MouseEvent } from "react";
 import { useEffect, useState } from "react";
-import { SignInButtons } from "@/components/auth/sign-in-buttons";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { useSession } from "@/utils/auth-client";
 import EditPreferencesContent from "./edit-preferences-content";
+import { WelcomeView } from "./onboarding";
 import SidebarContent from "./sidebar/sidebar-content";
 
 export type CalendarRange = {
@@ -190,6 +191,7 @@ export function DesktopToolbar(): React.JSX.Element {
 
   const [profileAnchor, setProfileAnchor] = useState<null | HTMLElement>(null);
   const profileOpen = Boolean(profileAnchor);
+  const [welcomeOpen, setWelcomeOpen] = useState(false);
   const [editPreferencesOpen, setEditPreferencesOpen] = useState(false);
   const [editPreferencesSnackbarOpen, setEditPreferencesSnackbarOpen] =
     useState(false);
@@ -316,8 +318,29 @@ export function DesktopToolbar(): React.JSX.Element {
                   />
                 </IconButton>
               ) : (
-                <div className="flex flex-col gap-2">
-                  <SignInButtons fullWidth={false} />
+                <div className="flex items-center gap-1">
+                  <IconButton
+                    onClick={() => setWelcomeOpen(true)}
+                    aria-label="Sign in"
+                  >
+                    <LoginIcon
+                      sx={{
+                        fontSize: 28,
+                        color: isTransparent ? "white" : "primary.main",
+                      }}
+                    />
+                  </IconButton>
+                  <IconButton
+                    onClick={handleProfileOpen}
+                    aria-label="Open menu"
+                  >
+                    <MenuIcon
+                      sx={{
+                        fontSize: 28,
+                        color: isTransparent ? "white" : "text.primary",
+                      }}
+                    />
+                  </IconButton>
                 </div>
               )}
             </div>
@@ -350,6 +373,32 @@ export function DesktopToolbar(): React.JSX.Element {
           onEditPreferencesClick={handleEditPreferencesOpen}
         />
       </Menu>
+
+      <Dialog
+        open={welcomeOpen}
+        onClose={() => setWelcomeOpen(false)}
+        maxWidth={false}
+        slotProps={{
+          paper: {
+            sx: {
+              width: "520px",
+              maxWidth: "90vw",
+              margin: 2,
+              padding: 0,
+              overflow: "hidden",
+              borderRadius: "16px",
+              ".dark &": {
+                border: "3px solid",
+                borderColor: "var(--mui-palette-divider)",
+                backgroundImage: "none",
+                backgroundColor: "var(--surface-modal)",
+              },
+            },
+          },
+        }}
+      >
+        <WelcomeView />
+      </Dialog>
 
       {isDesktop ? (
         <Dialog
@@ -404,6 +453,7 @@ function MobileToolbar(): React.JSX.Element {
   const isTransparent = TRANSPARENT_PAGES.includes(pathname);
   const [profileAnchor, setProfileAnchor] = useState<null | HTMLElement>(null);
   const profileOpen = Boolean(profileAnchor);
+  const [welcomeOpen, setWelcomeOpen] = useState(false);
   const { data: session, isPending } = useSession();
   const user = session?.user;
   const [isMounted, setIsMounted] = useState(false);
@@ -507,7 +557,38 @@ function MobileToolbar(): React.JSX.Element {
               />
             </IconButton>
           ) : (
-            <SignInButtons fullWidth={false} />
+            <>
+              <IconButton
+                type="button"
+                onClick={() => setWelcomeOpen(true)}
+                className="!p-0 !min-w-[44px] !min-h-[44px]"
+                aria-label="Sign in"
+              >
+                <LoginIcon
+                  style={{ fontSize: 30 }}
+                  className={
+                    isTransparent
+                      ? "text-white"
+                      : "text-sky-700 dark:text-blue-300"
+                  }
+                />
+              </IconButton>
+              <IconButton
+                type="button"
+                onClick={handleProfileOpen}
+                className="!p-0 !min-w-[44px] !min-h-[44px]"
+                aria-label="Open menu"
+              >
+                <MenuIcon
+                  style={{ fontSize: 30 }}
+                  className={
+                    isTransparent
+                      ? "text-white"
+                      : "text-neutral-800 dark:text-neutral-100"
+                  }
+                />
+              </IconButton>
+            </>
           )}
         </div>
       </div>
@@ -583,6 +664,20 @@ function MobileToolbar(): React.JSX.Element {
           onClose={handleProfileClose}
           onEditPreferencesClick={handleEditPreferencesOpen}
         />
+      </Drawer>
+
+      <Drawer
+        anchor="bottom"
+        open={welcomeOpen}
+        onClose={() => setWelcomeOpen(false)}
+        slotProps={{
+          paper: {
+            className:
+              "p-0 overflow-hidden rounded-t-[10px] h-auto max-h-[85vh] bg-white dark:bg-zinc-900",
+          },
+        }}
+      >
+        <WelcomeView />
       </Drawer>
 
       <Drawer


### PR DESCRIPTION
## Summary
Changed the logged-out toolbar so users now open a guest menu from the top-right instead of seeing a direct Sign In button. It now behaves consistently on both desktop and mobile and is closer to the Figma.

## Changes
- Added a guest icon menu for logged out users on mobile and pc.
- Replaced the desktop Sign In button with the guest menu.

## Testing Instructions
While logged out on desktop look at the toolbar and see if there is the guest icon rather than the direct sign-in button.

Closes #745